### PR TITLE
Integrate `authentication` with frontend and private pages with middleware

### DIFF
--- a/actions/auth/check-user.ts
+++ b/actions/auth/check-user.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { constants } from "@/config/constants";
+import { prismaClient } from "@/lib/prisma-client";
+import { jwtVerify } from "jose";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export async function checkUserAction() {
+  const cookieStorage = await cookies();
+  const token = cookieStorage.get(constants.accessToken)?.value;
+
+  if (!token) return redirect("/sign-in?action=logout");
+
+  try {
+    const { payload } = await jwtVerify(
+      token,
+      new TextEncoder().encode(process.env.JWT_SECRET!)
+    );
+
+    const user = await prismaClient.users.findUnique({
+      where: {
+        id: payload.sub,
+      },
+    });
+
+    if (!user) return redirect("/sign-in?action=logout");
+
+    return user;
+  } catch {
+    return redirect("/sign-in?action=logout");
+  }
+}

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -1,27 +1,28 @@
 "use server";
 
+import { constants } from "@/config/constants";
 import { auth } from "@/models/auth";
 import type { SignInProps } from "@/types/sign-in";
 import type { SignUpProps } from "@/types/sign-up";
+import { cookies } from "next/headers";
 
 export async function signUpAction(data: SignUpProps) {
   const result = await auth.signUp(data);
-
-  // TODO: handle result
-  // 1. add toast to show error or success message
-  // 2. redirect to sign-in page if success
-  console.log({ result });
-
-  return {};
+  return result;
 }
 
 export async function signInAction(data: SignInProps) {
   const result = await auth.signIn(data);
 
-  // TODO: handle result
-  // 1. add toast to show error or success message
-  // 2. redirect to dashboard page if success
-  console.log({ result });
+  if (result.token) {
+    const sevenDaysInMilliseconds = 60 * 60 * 24 * 7 * 1000;
 
-  return {};
+    const cookieStorage = await cookies();
+    cookieStorage.set(constants.accessToken, result.token, {
+      httpOnly: true,
+      expires: new Date(Date.now() + sevenDaysInMilliseconds),
+    });
+  }
+
+  return result;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
 
 export default function RootLayout({
@@ -7,7 +8,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-screen">
-      <body className="antialiased h-full">{children}</body>
+      <body className="antialiased h-full">
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,7 @@
-export default function Page() {
-  return <div>Hello World from Smart Translator</div>;
+import { checkUserAction } from "@/actions/auth/check-user";
+
+export default async function Page() {
+  const user = await checkUserAction();
+
+  return <div>Hello, {user.name}</div>;
 }

--- a/components/sign-in.tsx
+++ b/components/sign-in.tsx
@@ -14,7 +14,9 @@ import { cn } from '@/lib/utils';
 import { signInSchema } from '@/types/sign-in';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import type { z } from 'zod';
 import {
   Form,
@@ -31,6 +33,8 @@ export function SignInForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<'div'>) {
+  const route = useRouter();
+
   const form = useForm<FormData>({
     resolver: zodResolver(signInSchema),
     defaultValues: {
@@ -39,8 +43,16 @@ export function SignInForm({
     },
   });
 
-  function onSubmit(data: FormData) {
-    signInAction(data);
+  async function onSubmit(data: FormData) {
+    const { error } = await signInAction(data);
+
+    if (error) {
+      toast.error(JSON.parse(JSON.stringify(error)));
+      return;
+    }
+
+    toast.success('User logged in successfully');
+    route.push('/');
   }
 
   return (

--- a/components/sign-up.tsx
+++ b/components/sign-up.tsx
@@ -14,7 +14,9 @@ import { cn } from '@/lib/utils';
 import { signUpSchema } from '@/types/sign-up';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import type { z } from 'zod';
 import {
   Form,
@@ -31,6 +33,8 @@ export function SignUpForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<'div'>) {
+  const route = useRouter();
+
   const form = useForm<FormData>({
     resolver: zodResolver(signUpSchema),
     defaultValues: {
@@ -40,8 +44,16 @@ export function SignUpForm({
     },
   });
 
-  function onSubmit(data: FormData) {
-    signUpAction(data);
+  async function onSubmit(data: FormData) {
+    const { error, message } = await signUpAction(data);
+
+    if (error) {
+      toast.error(JSON.parse(JSON.stringify(error)));
+      return;
+    }
+
+    toast.success(message);
+    route.push('/sign-in');
   }
 
   return (
@@ -94,7 +106,7 @@ export function SignUpForm({
                     <FormItem>
                       <FormLabel>Password</FormLabel>
                       <FormControl>
-                        <Input placeholder="********" {...field} />
+                        <Input type='password' placeholder="********" {...field} />
                       </FormControl>
 
                       <FormMessage />
@@ -108,7 +120,7 @@ export function SignUpForm({
               <div className="mt-4 text-center text-sm">
                 Already have an account?{' '}
                 <Link href="/sign-in" className="underline underline-offset-4">
-                  Sign up
+                  Sign in
                 </Link>
               </div>
             </form>

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner } from "sonner"
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,0 +1,3 @@
+export const constants = {
+  accessToken: "smart-translator:accessToken",
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,49 @@
+import { cookies } from "next/headers";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { constants } from "./config/constants";
+
+import { jwtVerify } from "jose";
+
+const publicPaths = ["/sign-in", "/sign-up"];
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const cookieStore = await cookies();
+
+  const isLogoutAction =
+    request.nextUrl.searchParams.get("action") === "logout";
+
+  if (isLogoutAction) {
+    cookieStore.delete(constants.accessToken);
+    return NextResponse.redirect(new URL("/sign-in", request.url));
+  }
+
+  const token = cookieStore.get(constants.accessToken)?.value;
+
+  if (token && publicPaths.includes(pathname)) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  const isPrivatePath = !publicPaths.includes(pathname);
+
+  if (!token && isPrivatePath) {
+    return NextResponse.redirect(new URL("/sign-in", request.url));
+  }
+
+  if (token && isPrivatePath) {
+    try {
+      await jwtVerify(token, new TextEncoder().encode(process.env.JWT_SECRET!));
+    } catch {
+      cookieStore.delete(constants.accessToken);
+      return NextResponse.redirect(new URL("/sign-in", request.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher:
+    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm services:up && next dev --turbopack",
+    "dev": "pnpm services:up && pnpm prisma migrate dev && next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -27,9 +27,11 @@
     "jose": "5.9.6",
     "lucide-react": "0.474.0",
     "next": "15.1.6",
+    "next-themes": "0.4.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-hook-form": "7.54.2",
+    "sonner": "1.7.4",
     "tailwind-merge": "3.0.1",
     "tailwindcss-animate": "1.0.7",
     "zod": "3.24.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       next:
         specifier: 15.1.6
         version: 15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-themes:
+        specifier: 0.4.4
+        version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -47,6 +50,9 @@ importers:
       react-hook-form:
         specifier: 7.54.2
         version: 7.54.2(react@19.0.0)
+      sonner:
+        specifier: 1.7.4
+        version: 1.7.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tailwind-merge:
         specifier: 3.0.1
         version: 3.0.1
@@ -1109,6 +1115,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  next-themes@0.4.4:
+    resolution: {integrity: sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   next@15.1.6:
     resolution: {integrity: sha512-Hch4wzbaX0vKQtalpXvUiw5sYivBy4cm5rzUKrBnUB/y436LGrvOUqYvlSeNVCWFO/770gDlltR9gqZH62ct4Q==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -1354,6 +1366,12 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  sonner@1.7.4:
+    resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2448,6 +2466,11 @@ snapshots:
 
   nanoid@3.3.8: {}
 
+  next-themes@0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.1.6
@@ -2696,6 +2719,11 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
     optional: true
+
+  sonner@1.7.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Done
- Created centralized project `constants` file
- Created `Toaster` wth shadcn sonner
- Improved `auth` actions by returning the result and saving `token` on cookies
- Integrated `/sign-up` page with error or success feedback messages
- Integrated `/sign-in` page with error or success feedback messages
- Created `middleware` to verify public and private pages
- Created `checkUserAction` util function

## Preview
[Gravação de tela de 09-02-2025 16:10:12.webm](https://github.com/user-attachments/assets/00f3e8fc-240f-4b20-bde6-d975eedb9a71)
