### PR TITLE
Refactors `gemini model` public interface

### DIFF
--- a/actions/auth/check-user.ts
+++ b/actions/auth/check-user.ts
@@ -1,21 +1,21 @@
-"use server";
+'use server';
 
-import { constants } from "@/config/constants";
-import { prismaClient } from "@/lib/prisma-client";
-import { jwtVerify } from "jose";
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
+import { constants } from '@/config/constants';
+import { prismaClient } from '@/lib/prisma-client';
+import { jwtVerify } from 'jose';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 export async function checkUserAction() {
   const cookieStorage = await cookies();
   const token = cookieStorage.get(constants.accessToken)?.value;
 
-  if (!token) return redirect("/sign-in?action=logout");
+  if (!token) return redirect('/sign-in?action=logout');
 
   try {
     const { payload } = await jwtVerify(
       token,
-      new TextEncoder().encode(process.env.JWT_SECRET!)
+      new TextEncoder().encode(process.env.JWT_SECRET!),
     );
 
     const user = await prismaClient.users.findUnique({
@@ -24,10 +24,10 @@ export async function checkUserAction() {
       },
     });
 
-    if (!user) return redirect("/sign-in?action=logout");
+    if (!user) return redirect('/sign-in?action=logout');
 
     return user;
   } catch {
-    return redirect("/sign-in?action=logout");
+    return redirect('/sign-in?action=logout');
   }
 }

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -1,10 +1,10 @@
-"use server";
+'use server';
 
-import { constants } from "@/config/constants";
-import { auth } from "@/models/auth";
-import type { SignInProps } from "@/types/sign-in";
-import type { SignUpProps } from "@/types/sign-up";
-import { cookies } from "next/headers";
+import { constants } from '@/config/constants';
+import { auth } from '@/models/auth';
+import type { SignInProps } from '@/types/sign-in';
+import type { SignUpProps } from '@/types/sign-up';
+import { cookies } from 'next/headers';
 
 export async function signUpAction(data: SignUpProps) {
   const result = await auth.signUp(data);

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -5,7 +5,7 @@ import { GeminiServiceError } from "@/errors/gemini-service-error";
 import { ParseTextError } from "@/errors/parse-text-error";
 import { ParseZodError } from "@/errors/parse-zod-error";
 import { prismaClient } from "@/lib/prisma-client";
-import { generateTranslation } from "@/models/gemini";
+import { gemini } from "@/models/gemini";
 
 export type TranslationResponse = {
   ok: boolean;
@@ -27,7 +27,7 @@ export async function generateTranslationAction(
 
   try {
     const user = await checkUserAction();
-    const result = await generateTranslation(wordToTranslate);
+    const result = await gemini.generateTranslation(wordToTranslate);
 
     await prismaClient.translations.create({
       data: {

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,11 +1,11 @@
-"use server";
+'use server';
 
-import { checkUserAction } from "@/actions/auth/check-user";
-import { GeminiServiceError } from "@/errors/gemini-service-error";
-import { ParseTextError } from "@/errors/parse-text-error";
-import { ParseZodError } from "@/errors/parse-zod-error";
-import { prismaClient } from "@/lib/prisma-client";
-import { gemini } from "@/models/gemini";
+import { checkUserAction } from '@/actions/auth/check-user';
+import { GeminiServiceError } from '@/errors/gemini-service-error';
+import { ParseTextError } from '@/errors/parse-text-error';
+import { ParseZodError } from '@/errors/parse-zod-error';
+import { prismaClient } from '@/lib/prisma-client';
+import { gemini } from '@/models/gemini';
 
 export type TranslationResponse = {
   ok: boolean;
@@ -16,14 +16,14 @@ export type TranslationResponse = {
 
 const defaultErrorObject = {
   ok: false,
-  error: "Something went wrong while generating the translation.",
+  error: 'Something went wrong while generating the translation.',
 };
 
 export async function generateTranslationAction(
   _prevState: unknown,
-  formData: FormData
+  formData: FormData,
 ): Promise<TranslationResponse> {
-  const wordToTranslate = formData.get("word_to_translate") as string;
+  const wordToTranslate = formData.get('word_to_translate') as string;
 
   try {
     const user = await checkUserAction();
@@ -32,8 +32,8 @@ export async function generateTranslationAction(
     await prismaClient.translations.create({
       data: {
         userId: user.id,
-        languageFrom: "en",
-        languageTo: "pt",
+        languageFrom: 'en',
+        languageTo: 'pt',
         targetWord: wordToTranslate,
         translatedWord: result.output,
         phrases: {
@@ -64,7 +64,7 @@ export async function generateTranslationAction(
     if (error instanceof GeminiServiceError) {
       return {
         ...defaultErrorObject,
-        module: "gemini",
+        module: 'gemini',
         word_to_translate: wordToTranslate,
       };
     }
@@ -72,7 +72,7 @@ export async function generateTranslationAction(
     if (error instanceof ParseTextError) {
       return {
         ...defaultErrorObject,
-        module: "parse-text",
+        module: 'parse-text',
         word_to_translate: wordToTranslate,
       };
     }
@@ -80,7 +80,7 @@ export async function generateTranslationAction(
     if (error instanceof ParseZodError) {
       return {
         ...defaultErrorObject,
-        module: "parse-zod",
+        module: 'parse-zod',
         word_to_translate: wordToTranslate,
       };
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import { checkUserAction } from "@/actions/auth/check-user";
-import { GenerateTranslationForm } from "@/components/generate-translation-form";
+import { checkUserAction } from '@/actions/auth/check-user';
+import { GenerateTranslationForm } from '@/components/generate-translation-form';
 
 export default async function Page() {
   const user = await checkUserAction();
@@ -7,9 +7,7 @@ export default async function Page() {
   return (
     <div className="h-full grid place-items-center">
       <div className="h-full flex flex-col items-center justify-center">
-        <h1>
-          Hello, {user.name}
-        </h1>
+        <h1>Hello, {user.name}</h1>
 
         <GenerateTranslationForm />
       </div>

--- a/components/generate-translation-form.tsx
+++ b/components/generate-translation-form.tsx
@@ -1,17 +1,20 @@
-'use client'
+'use client';
 
-import { generateTranslationAction } from "@/app/actions";
-import { useActionState, useEffect } from "react";
-import { toast } from "sonner";
-import { Button } from "./ui/button";
-import { Input } from "./ui/input";
+import { generateTranslationAction } from '@/app/actions';
+import { useActionState, useEffect } from 'react';
+import { toast } from 'sonner';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
 
 export function GenerateTranslationForm() {
-  const [state, action, isPending] = useActionState(generateTranslationAction, null);
+  const [state, action, isPending] = useActionState(
+    generateTranslationAction,
+    null,
+  );
 
   useEffect(() => {
     if (state?.ok) {
-      toast.success("Translation generated successfully!");
+      toast.success('Translation generated successfully!');
       return;
     }
 
@@ -21,25 +24,28 @@ export function GenerateTranslationForm() {
         action: {
           label: 'Contact Support',
           onClick: () => {
-            console.log(`Contact support about ${state.module} error when trying to generate a translation.`);
+            console.log(
+              `Contact support about ${state.module} error when trying to generate a translation.`,
+            );
           },
         },
         duration: 5000,
       });
     }
-  }, [state])
+  }, [state]);
 
   return (
     <form action={action} className="space-y-2">
-
-      <Input required placeholder="Word to translate" name="word_to_translate" defaultValue={state?.word_to_translate} />
+      <Input
+        required
+        placeholder="Word to translate"
+        name="word_to_translate"
+        defaultValue={state?.word_to_translate}
+      />
 
       <Button disabled={isPending}>
-        {
-          isPending ? "Generating Translation..." : "Generate Translation"
-        }
+        {isPending ? 'Generating Translation...' : 'Generate Translation'}
       </Button>
-
     </form>
-  )
+  );
 }

--- a/components/sign-up.tsx
+++ b/components/sign-up.tsx
@@ -106,7 +106,11 @@ export function SignUpForm({
                     <FormItem>
                       <FormLabel>Password</FormLabel>
                       <FormControl>
-                        <Input type='password' placeholder="********" {...field} />
+                        <Input
+                          type="password"
+                          placeholder="********"
+                          {...field}
+                        />
                       </FormControl>
 
                       <FormMessage />

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,31 +1,31 @@
-"use client"
+'use client';
 
-import { useTheme } from "next-themes"
-import { Toaster as Sonner } from "sonner"
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner } from 'sonner';
 
-type ToasterProps = React.ComponentProps<typeof Sonner>
+type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = 'system' } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme as ToasterProps['theme']}
       className="toaster group"
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
           actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
         },
       }}
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,3 +1,3 @@
 export const constants = {
-  accessToken: "smart-translator:accessToken",
+  accessToken: 'smart-translator:accessToken',
 };

--- a/errors/gemini-service-error.ts
+++ b/errors/gemini-service-error.ts
@@ -1,6 +1,6 @@
 export class GeminiServiceError extends Error {
   constructor() {
     super();
-    this.name = "GeminiServiceError";
+    this.name = 'GeminiServiceError';
   }
 }

--- a/errors/parse-text-error.ts
+++ b/errors/parse-text-error.ts
@@ -1,6 +1,6 @@
 export class ParseTextError extends Error {
   constructor() {
     super();
-    this.name = "ParseTextError";
+    this.name = 'ParseTextError';
   }
 }

--- a/errors/parse-zod-error.ts
+++ b/errors/parse-zod-error.ts
@@ -1,6 +1,6 @@
 export class ParseZodError extends Error {
   constructor() {
     super();
-    this.name = "ParseZodError";
+    this.name = 'ParseZodError';
   }
 }

--- a/lib/prisma-client.ts
+++ b/lib/prisma-client.ts
@@ -1,3 +1,3 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client';
 
 export const prismaClient = new PrismaClient();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,34 +1,34 @@
-import { cookies } from "next/headers";
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { constants } from "./config/constants";
+import { cookies } from 'next/headers';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { constants } from './config/constants';
 
-import { jwtVerify } from "jose";
+import { jwtVerify } from 'jose';
 
-const publicPaths = ["/sign-in", "/sign-up"];
+const publicPaths = ['/sign-in', '/sign-up'];
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const cookieStore = await cookies();
 
   const isLogoutAction =
-    request.nextUrl.searchParams.get("action") === "logout";
+    request.nextUrl.searchParams.get('action') === 'logout';
 
   if (isLogoutAction) {
     cookieStore.delete(constants.accessToken);
-    return NextResponse.redirect(new URL("/sign-in", request.url));
+    return NextResponse.redirect(new URL('/sign-in', request.url));
   }
 
   const token = cookieStore.get(constants.accessToken)?.value;
 
   if (token && publicPaths.includes(pathname)) {
-    return NextResponse.redirect(new URL("/", request.url));
+    return NextResponse.redirect(new URL('/', request.url));
   }
 
   const isPrivatePath = !publicPaths.includes(pathname);
 
   if (!token && isPrivatePath) {
-    return NextResponse.redirect(new URL("/sign-in", request.url));
+    return NextResponse.redirect(new URL('/sign-in', request.url));
   }
 
   if (token && isPrivatePath) {
@@ -36,7 +36,7 @@ export async function middleware(request: NextRequest) {
       await jwtVerify(token, new TextEncoder().encode(process.env.JWT_SECRET!));
     } catch {
       cookieStore.delete(constants.accessToken);
-      return NextResponse.redirect(new URL("/sign-in", request.url));
+      return NextResponse.redirect(new URL('/sign-in', request.url));
     }
   }
 
@@ -45,5 +45,5 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher:
-    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
 };

--- a/models/auth.ts
+++ b/models/auth.ts
@@ -1,9 +1,9 @@
-import { prismaClient } from "@/lib/prisma-client";
-import { type SignInProps, signInSchema } from "@/types/sign-in";
-import { type SignUpProps, signUpSchema } from "@/types/sign-up";
-import bcrypt from "bcrypt";
+import { prismaClient } from '@/lib/prisma-client';
+import { type SignInProps, signInSchema } from '@/types/sign-in';
+import { type SignUpProps, signUpSchema } from '@/types/sign-up';
+import bcrypt from 'bcrypt';
 
-import { SignJWT } from "jose";
+import { SignJWT } from 'jose';
 
 async function signUp(input: SignUpProps) {
   const { data, error } = signUpSchema.safeParse(input);
@@ -19,7 +19,7 @@ async function signUp(input: SignUpProps) {
   });
 
   if (userAlreadyExists) {
-    return { error: "User already exists!" };
+    return { error: 'User already exists!' };
   }
 
   const SALT = 10;
@@ -34,7 +34,7 @@ async function signUp(input: SignUpProps) {
   });
 
   return {
-    message: "User created successfully!",
+    message: 'User created successfully!',
   };
 }
 
@@ -52,23 +52,23 @@ async function signIn(input: SignInProps) {
   });
 
   if (!user) {
-    return { error: "Invalid credentials!" };
+    return { error: 'Invalid credentials!' };
   }
 
   const passwordMatch = await bcrypt.compare(password, user.password);
 
   if (!passwordMatch) {
-    return { error: "Invalid credentials!" };
+    return { error: 'Invalid credentials!' };
   }
 
   const secret = new TextEncoder().encode(process.env.JWT_SECRET);
 
   const token = await new SignJWT({ sub: user.id })
     .setProtectedHeader({
-      alg: "HS256",
-      typ: "JWT",
+      alg: 'HS256',
+      typ: 'JWT',
     })
-    .setExpirationTime("7d")
+    .setExpirationTime('7d')
     .setIssuedAt()
     .sign(secret);
 

--- a/models/gemini.ts
+++ b/models/gemini.ts
@@ -1,8 +1,8 @@
-import { GeminiServiceError } from "@/errors/gemini-service-error";
-import { ParseTextError } from "@/errors/parse-text-error";
-import { ParseZodError } from "@/errors/parse-zod-error";
-import { GoogleGenerativeAI } from "@google/generative-ai";
-import { z } from "zod";
+import { GeminiServiceError } from '@/errors/gemini-service-error';
+import { ParseTextError } from '@/errors/parse-text-error';
+import { ParseZodError } from '@/errors/parse-zod-error';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { z } from 'zod';
 
 const geminiResponseSchema = z.object({
   input: z.string(),
@@ -19,10 +19,10 @@ async function generateTranslation(wordToTranslate: string) {
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
 
   const model = genAI.getGenerativeModel({
-    model: "gemini-1.5-flash",
+    model: 'gemini-1.5-flash',
   });
 
-  let responseText = "";
+  let responseText = '';
 
   try {
     const prompt = generateCustomizedPrompt(wordToTranslate);
@@ -30,11 +30,11 @@ async function generateTranslation(wordToTranslate: string) {
     responseText = response.text();
   } catch (error) {
     // TODO: log to an external service
-    console.log("Gemini Error: ", error);
+    console.log('Gemini Error: ', error);
     throw new GeminiServiceError();
   }
 
-  responseText = responseText.replace(/```json|```/g, "").trim();
+  responseText = responseText.replace(/```json|```/g, '').trim();
 
   try {
     const parsedResponse = JSON.parse(responseText);
@@ -44,8 +44,8 @@ async function generateTranslation(wordToTranslate: string) {
     if (!validatedOutput.success) {
       // TODO: log to an external service
       console.log(
-        "Zod validation error: ",
-        JSON.stringify(validatedOutput, null, 2)
+        'Zod validation error: ',
+        JSON.stringify(validatedOutput, null, 2),
       );
       throw new ParseZodError();
     }
@@ -53,7 +53,7 @@ async function generateTranslation(wordToTranslate: string) {
     return validatedOutput.data;
   } catch (error) {
     // TODO: log to an external service
-    console.log("Parse Error: ", error);
+    console.log('Parse Error: ', error);
     throw new ParseTextError();
   }
 }

--- a/models/gemini.ts
+++ b/models/gemini.ts
@@ -15,7 +15,7 @@ const geminiResponseSchema = z.object({
   phrase_3_translated: z.string(),
 });
 
-export async function generateTranslation(wordToTranslate: string) {
+async function generateTranslation(wordToTranslate: string) {
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
 
   const model = genAI.getGenerativeModel({
@@ -77,3 +77,7 @@ Generate an output **ONLY in valid JSON format**, without any other characters, 
 }
   `;
 }
+
+export const gemini = {
+  generateTranslation,
+};

--- a/test/models/auth.test.ts
+++ b/test/models/auth.test.ts
@@ -1,80 +1,80 @@
-import { prismaClient } from "@/lib/prisma-client";
-import { auth } from "@/models/auth";
-import { randomUUID } from "node:crypto";
+import { randomUUID } from 'node:crypto';
+import { prismaClient } from '@/lib/prisma-client';
+import { auth } from '@/models/auth';
 
 beforeAll(async () => {
   await prismaClient.users.deleteMany();
 });
 
-describe("models > auth", () => {
+describe('models > auth', () => {
   describe("Invoking 'signUp' method", () => {
-    it("should return an error when providing a invalid email input", async () => {
-      const invalidEmail = "invalid-email";
+    it('should return an error when providing a invalid email input', async () => {
+      const invalidEmail = 'invalid-email';
 
       const result = await auth.signUp({
         email: invalidEmail,
-        name: "John Doe",
+        name: 'John Doe',
         password: randomUUID(),
       });
 
       expect(result).toStrictEqual({
         error: {
-          email: ["Invalid email"],
+          email: ['Invalid email'],
         },
       });
     });
 
-    it("should return a successfull message when creating a new user", async () => {
+    it('should return a successfull message when creating a new user', async () => {
       const result = await auth.signUp({
-        email: "test@mail.com",
-        name: "John Doe",
+        email: 'test@mail.com',
+        name: 'John Doe',
         password: randomUUID(),
       });
 
       expect(result).toStrictEqual({
-        message: "User created successfully!",
+        message: 'User created successfully!',
       });
     });
   });
 
   describe("Invoking 'signIn' method", () => {
-    it("should return an error when providing a non existing email", async () => {
+    it('should return an error when providing a non existing email', async () => {
       const result = await auth.signIn({
-        email: "non-existing-email@mail.com",
+        email: 'non-existing-email@mail.com',
         password: randomUUID(),
       });
 
       expect(result).toStrictEqual({
-        error: "Invalid credentials!",
+        error: 'Invalid credentials!',
       });
     });
 
-    it("should return an error when providing a wrong password", async () => {
-      const email = "testemail@email.com";
+    it('should return an error when providing a wrong password', async () => {
+      const email = 'testemail@email.com';
 
       await auth.signUp({
         email,
-        name: "John Doe",
-        password: "123456",
+        name: 'John Doe',
+        password: '123456',
       });
 
       const result = await auth.signIn({
         email,
-        password: "wrong-password",
+        password: 'wrong-password',
       });
 
       expect(result).toStrictEqual({
-        error: "Invalid credentials!",
+        error: 'Invalid credentials!',
       });
     });
 
-    it("should return a JWT token when providing valid properties", async () => {
-      const email = "successfull@email.com";
-      const password = "123456";
+    it('should return a JWT token when providing valid properties', async () => {
+      const email = 'successfull@email.com';
+      const password = '123456';
 
       await auth.signUp({
         email,
-        name: "John Doe",
+        name: 'John Doe',
         password,
       });
 
@@ -83,7 +83,7 @@ describe("models > auth", () => {
         password,
       });
 
-      expect(result).toHaveProperty("token");
+      expect(result).toHaveProperty('token');
     });
   });
 });

--- a/types/sign-in.ts
+++ b/types/sign-in.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 export type SignInProps = z.infer<typeof signInSchema>;
 

--- a/types/sign-up.ts
+++ b/types/sign-up.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 export type SignUpProps = z.infer<typeof signUpSchema>;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import viteTsConfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
+import viteTsConfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [viteTsConfigPaths()],


### PR DESCRIPTION
## Done
- refactored `models/gemini` file by changing the puiblic interface of `generateTranslation` method.
  - before, I used this method by just importing and calling directly `generateTranslation`
  - now, to use this method, I have to import a `gemini` constant, that has `generateTranslation` as a function
  -
  ```ts
  // before
  const resultBefore = await generateTranslation("word");
  
  // after
  const resultAfter = await gemini.generateTranslation("word");
  ```
  
 - Adjusted the codebase standard by running `pnpm biome:fix` command