### PR TITLE
Integrates homepage with backend and implements `translation cache behavior`

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -6,6 +6,7 @@ import { ParseTextError } from '@/errors/parse-text-error';
 import { ParseZodError } from '@/errors/parse-zod-error';
 import { prismaClient } from '@/lib/prisma-client';
 import { gemini } from '@/models/gemini';
+import { revalidatePath } from 'next/cache';
 
 export type TranslationResponse = {
   ok: boolean;
@@ -56,6 +57,8 @@ export async function generateTranslationAction(
         },
       },
     });
+
+    revalidatePath('/');
 
     return {
       ok: true,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,55 +1,151 @@
 import { checkUserAction } from '@/actions/auth/check-user';
 import { GenerateTranslationForm } from '@/components/generate-translation-form';
 import { Input } from '@/components/ui/input';
+import { prismaClient } from '@/lib/prisma-client';
 
 export default async function Page() {
   const user = await checkUserAction();
 
+  const translations = await prismaClient.translations.findMany({
+    where: {
+      userId: user.id,
+    },
+    include: {
+      phrases: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+
+  const latestTranslation = translations[0];
+
   return (
     <div className="h-full">
-      <header className='bg-black text-white h-16 flex justify-between items-center px-4'>
-        <h1 className='text-2xl font-bold'>
-          Smart Translator
-        </h1>
+      <header className="bg-black text-white h-16 flex justify-between items-center px-4">
+        <h1 className="text-2xl font-bold">Smart Translator</h1>
 
-        <span>
-          Hello, {user.name}
-        </span>
+        <span>Hello, {user.name}</span>
       </header>
 
-      <main className="h-[calc(100%-64px)] flex flex-col px-6 py-12">
-        <div className='flex flex-col h-1/2 md:h-1/3 sm:flex-row gap-4'>
-          <div className='rounded w-full xl:w-1/2 flex flex-col'>
-            <h2 className='mb-3  text-xl font-medium'>Translate a word</h2>
+      <main className="h-[calc(100%-64px)] flex flex-col px-6 py-12 space-y-4">
+        <div className="flex flex-col sm:flex-row gap-4">
+          <div className="rounded w-full xl:w-1/2 flex flex-col">
+            <h2 className="mb-3  text-xl font-medium">Translate a word</h2>
 
             <GenerateTranslationForm />
           </div>
 
-          <div className='rounded w-full xl:w-1/2'>
-            <h2 className='mb-3 text-xl font-medium'>Latest translations</h2>
+          <div className="rounded w-full xl:w-1/2">
+            <h2 className="mb-3 text-xl font-medium">Latest translations</h2>
 
-            <div className='border rounded p-4'>
-              <p className='text-center text-slate-400'>No translations yet. Enter a word to translate.</p>
+            <div className="border rounded p-4">
+              {translations.length === 0 ? (
+                <p className="text-center text-slate-400">
+                  No translations yet. Enter a word to translate.
+                </p>
+              ) : (
+                <div className="flex flex-col">
+                  <div className="flex flex-col">
+                    <span className="text-lg font-bold">
+                      {latestTranslation.targetWord} (
+                      {latestTranslation.languageFrom}){' = '}
+                      {latestTranslation.translatedWord} (
+                      {latestTranslation.languageTo})
+                    </span>
+
+                    <span className="text-sm text-muted-foreground">
+                      {latestTranslation.createdAt.toLocaleDateString('en', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: 'numeric',
+                      })}
+                    </span>
+                  </div>
+
+                  <div>
+                    <ul className="space-y-2 mt-4">
+                      {latestTranslation.phrases.map((phrase) => (
+                        <li key={phrase.id} className="flex flex-col">
+                          <span className="font-bold">{phrase.content}</span>
+                          <span className="text-sm text-muted-foreground">
+                            {phrase.translatedContent}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </div>
 
-        <div className='h-full space-y-4'>
-          <h3 className='mb-3 text-xl font-medium'>
-            Translation History
-          </h3>
+        <div className="h-full space-y-4 pb-4 md:pb-0">
+          <h3 className="mb-3 text-xl font-medium">Translation History</h3>
 
           <form>
-            <label htmlFor="translation_search" className='text-slate-600 text-sm'>Search translations</label>
+            <label
+              htmlFor="translation_search"
+              className="text-slate-600 text-sm"
+            >
+              Search translations
+            </label>
             <Input
-              id='translation_search'
-              type='search'
-              placeholder='Search for a word or a translation...'
+              id="translation_search"
+              type="search"
+              placeholder="Search for a word or a translation..."
             />
           </form>
 
-          <div className='border rounded'>
-            <p className='text-slate-400 text-center py-10'>No translations found. Try a different search term or translate a new word.</p>
+          <div className="border rounded overflow-y-auto h-96 p-4 bg-background">
+            {translations.length === 0 ? (
+              <p className="text-slate-400 text-center py-10">
+                No translations found. Try a different search term or translate
+                a new word.
+              </p>
+            ) : (
+              translations.map((translation) => (
+                <div key={translation.id} className="shadow-md rounded p-4">
+                  <div className="text-xl">
+                    <div className="flex">
+                      <span className="font-bold">
+                        {translation.targetWord} ({translation.languageFrom})
+                      </span>
+                      {' = '}
+                      <span className="font-bold">
+                        {translation.translatedWord} ({translation.languageTo})
+                      </span>
+                    </div>
+
+                    <span className="text-muted-foreground">
+                      {translation.createdAt.toLocaleDateString('en', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: 'numeric',
+                      })}
+                    </span>
+                  </div>
+
+                  <div>
+                    <ul className="space-y-2 mt-4">
+                      {translation.phrases.map((phrase) => (
+                        <li key={phrase.id} className="flex flex-col">
+                          <span className="font-bold">{phrase.content}</span>
+                          <span className="text-muted-foreground">
+                            {phrase.translatedContent}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ))
+            )}
           </div>
         </div>
       </main>

--- a/components/generate-translation-form.tsx
+++ b/components/generate-translation-form.tsx
@@ -36,9 +36,11 @@ export function GenerateTranslationForm() {
 
   return (
     <form action={action} className="space-y-2 w-full xl:w-1/2 min-w-40">
-      <label htmlFor="word_to_translate" className='text-slate-600 text-sm'>Enter a word in English</label>
+      <label htmlFor="word_to_translate" className="text-slate-600 text-sm">
+        Enter a word in English
+      </label>
       <Input
-        id='word_to_translate'
+        id="word_to_translate"
         required
         placeholder="Word"
         name="word_to_translate"

--- a/prisma/migrations/20250225234759_removes_target_word_unique_constraint/migration.sql
+++ b/prisma/migrations/20250225234759_removes_target_word_unique_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "translations_target_word_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ model Users {
 
 model Translations {
   id             String   @id @default(uuid()) @db.Uuid
-  targetWord     String   @unique @map("target_word")
+  targetWord     String   @map("target_word")
   translatedWord String   @map("translated_word")
   languageFrom   String   @map("language_from")
   languageTo     String   @map("language_to")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,5 @@
-import { prismaClient } from "@/lib/prisma-client";
-import bcrypt from "bcrypt";
+import { prismaClient } from '@/lib/prisma-client';
+import bcrypt from 'bcrypt';
 
 async function main() {
   await Promise.all([
@@ -9,13 +9,13 @@ async function main() {
   ]);
 
   const SALT = 10;
-  const password = "123456";
+  const password = '123456';
   const hashedPassword = await bcrypt.hash(password, SALT);
 
   const { id: userId } = await prismaClient.users.create({
     data: {
-      email: "user@email.com",
-      name: "User",
+      email: 'user@email.com',
+      name: 'User',
       password: hashedPassword,
     },
   });
@@ -24,24 +24,24 @@ async function main() {
     prismaClient.translations.create({
       data: {
         userId,
-        languageFrom: "en",
-        languageTo: "pt",
-        targetWord: "hello",
-        translatedWord: "olá",
+        languageFrom: 'en',
+        languageTo: 'pt',
+        targetWord: 'hello',
+        translatedWord: 'olá',
         phrases: {
           createMany: {
             data: [
               {
-                content: "Hello, how are you?",
-                translatedContent: "Olá, como você está?",
+                content: 'Hello, how are you?',
+                translatedContent: 'Olá, como você está?',
               },
               {
-                content: "Hello, world!",
-                translatedContent: "Olá, mundo!",
+                content: 'Hello, world!',
+                translatedContent: 'Olá, mundo!',
               },
               {
-                content: "Hello, everyone!",
-                translatedContent: "Olá, pessoal!",
+                content: 'Hello, everyone!',
+                translatedContent: 'Olá, pessoal!',
               },
             ],
           },
@@ -51,24 +51,24 @@ async function main() {
     prismaClient.translations.create({
       data: {
         userId,
-        languageFrom: "en",
-        languageTo: "pt",
-        targetWord: "world",
-        translatedWord: "mundo",
+        languageFrom: 'en',
+        languageTo: 'pt',
+        targetWord: 'world',
+        translatedWord: 'mundo',
         phrases: {
           createMany: {
             data: [
               {
-                content: "Hello, world!",
-                translatedContent: "Olá, mundo!",
+                content: 'Hello, world!',
+                translatedContent: 'Olá, mundo!',
               },
               {
-                content: "The world is big.",
-                translatedContent: "O mundo é grande.",
+                content: 'The world is big.',
+                translatedContent: 'O mundo é grande.',
               },
               {
-                content: "The world is beautiful.",
-                translatedContent: "O mundo é bonito.",
+                content: 'The world is beautiful.',
+                translatedContent: 'O mundo é bonito.',
               },
             ],
           },


### PR DESCRIPTION
## Done
- Adjusted the codebase standard by running `pnpm biome:fix` command
- Removed `targetWord` unique constraint in `Translations` table
- Implemented cached result behavior in `generateTranslation` method to reduce AI model calls
- Integrated home page with the backend, retrieving all the user's translations

## Preview
[Gravação de tela de 25-02-2025 21:34:21.webm](https://github.com/user-attachments/assets/7df70d81-691a-4c5f-a0d5-131487554632)
