### PR TITLE
Adds input validations to improve gemini model call

### DIFF
--- a/components/generate-translation-form.tsx
+++ b/components/generate-translation-form.tsx
@@ -44,7 +44,9 @@ export function GenerateTranslationForm() {
         required
         placeholder="Word"
         name="word_to_translate"
-        defaultValue={state?.word_to_translate}
+        defaultValue={
+          state?.module === 'invalid-word' ? '' : state?.word_to_translate
+        }
       />
 
       <Button disabled={isPending}>

--- a/errors/invalid-word-error.ts
+++ b/errors/invalid-word-error.ts
@@ -1,0 +1,6 @@
+export class InvalidWordError extends Error {
+  constructor() {
+    super();
+    this.name = 'InvalidWordError';
+  }
+}

--- a/infra/scripts/wait-services.ts
+++ b/infra/scripts/wait-services.ts
@@ -1,9 +1,9 @@
-import chilProcess from "node:child_process";
-import { promisify } from "node:util";
+import chilProcess from 'node:child_process';
+import { promisify } from 'node:util';
 
 const exec = promisify(chilProcess.exec);
 
-const containerName = "smart-translator-local-db";
+const containerName = 'smart-translator-local-db';
 
 async function waitServices(attempts = 1) {
   if (attempts === 20) {
@@ -14,16 +14,16 @@ async function waitServices(attempts = 1) {
   try {
     const { stdout } = await exec(`docker exec ${containerName} pg_isready`);
 
-    if (!stdout.includes("accepting connections")) {
-      process.stdout.write(".");
+    if (!stdout.includes('accepting connections')) {
+      process.stdout.write('.');
       return waitServices(attempts + 1);
     }
   } catch {
-    process.stdout.write(".");
+    process.stdout.write('.');
     return waitServices(attempts + 1);
   }
 
-  console.log("\nServices are ready!");
+  console.log('\nServices are ready!');
 }
 
 waitServices();

--- a/models/gemini.ts
+++ b/models/gemini.ts
@@ -1,4 +1,5 @@
 import { GeminiServiceError } from '@/errors/gemini-service-error';
+import { InvalidWordError } from '@/errors/invalid-word-error';
 import { ParseTextError } from '@/errors/parse-text-error';
 import { ParseZodError } from '@/errors/parse-zod-error';
 import { prismaClient } from '@/lib/prisma-client';
@@ -59,6 +60,12 @@ async function generateTranslation(wordToTranslate: string) {
 
   responseText = responseText.replace(/```json|```/g, '').trim();
 
+  if (responseText === '{}') {
+    // TODO: log to an external service
+    console.log('Invalid Word Error');
+    throw new InvalidWordError();
+  }
+
   try {
     const parsedResponse = JSON.parse(responseText);
 
@@ -111,6 +118,8 @@ Generate an output **ONLY in valid JSON format**, without any other characters, 
   phrase_3_generated: string,
   phrase_3_translated: string
 }
+
+But, in case of the word is not a valid English word, return an empty object.
   `;
 }
 


### PR DESCRIPTION
## Done
- Added validation to check if the word is a valid english word before store in database
- Created custom error called `InvalidWordError`
- Added zod validation to limit input characters length and handles `InvalidWordError`, in `generateTranslationAction`
- Implemented a logic to reset the input if the error is about `invalid-word`
- Standardizes the codebase by running `pnpm biome:fix`

## Preview
[Gravação de tela de 07-03-2025 12:41:28.webm](https://github.com/user-attachments/assets/386541a7-d047-45be-b1d4-0befc5943d76)
