### PR TITLE
Componentize homepage sections to make the codebase more readable

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,11 +6,31 @@ import { TranslationsHistorySkeleton } from '@/components/translations-history-s
 import { prismaClient } from '@/lib/prisma-client';
 import { Suspense } from 'react';
 
-const tomorrowDate = new Date();
-tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+const now = new Date();
 
-const yesterdayDate = new Date();
-yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+const startOfToday = new Date(
+  Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    0,
+    0,
+    0,
+    0,
+  ),
+);
+
+const endOfToday = new Date(
+  Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    23,
+    59,
+    59,
+    999,
+  ),
+);
 
 export default async function Page() {
   const user = await checkUserAction();
@@ -32,8 +52,8 @@ export default async function Page() {
     where: {
       userId: user.id,
       createdAt: {
-        gte: yesterdayDate,
-        lt: tomorrowDate,
+        gte: startOfToday,
+        lte: endOfToday,
       },
     },
   });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,9 +34,9 @@ export default async function Page() {
       createdAt: {
         gte: yesterdayDate,
         lt: tomorrowDate,
-      }
-    }
-  })
+      },
+    },
+  });
 
   return (
     <div className="h-full">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,32 @@
+import { logout } from "@/actions/auth/logout";
+import { MenuIcon } from "./menu-icon";
+import { Button } from "./ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+
+type HeaderProps = {
+  name: string;
+}
+
+export function Header({ name }: HeaderProps) {
+  return (
+    <header className="bg-black text-white h-16 flex justify-between items-center px-4">
+      <h1 className="text-2xl font-bold">Smart Translator</h1>
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button>
+            <MenuIcon />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-fit">
+          <div className="space-y-2">
+            <span>Hello, {name}</span>
+            <form action={logout}>
+              <Button className="w-full">Logout</Button>
+            </form>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </header>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,11 +1,11 @@
-import { logout } from "@/actions/auth/logout";
-import { MenuIcon } from "./menu-icon";
-import { Button } from "./ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { logout } from '@/actions/auth/logout';
+import { MenuIcon } from './menu-icon';
+import { Button } from './ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 
 type HeaderProps = {
   name: string;
-}
+};
 
 export function Header({ name }: HeaderProps) {
   return (
@@ -28,5 +28,5 @@ export function Header({ name }: HeaderProps) {
         </PopoverContent>
       </Popover>
     </header>
-  )
+  );
 }

--- a/components/translations-history-skeleton.tsx
+++ b/components/translations-history-skeleton.tsx
@@ -1,0 +1,71 @@
+import { Input } from "./ui/input";
+import { Skeleton } from "./ui/skeleton";
+
+export async function TranslationsHistorySkeleton() {
+  return (
+    <div className="h-full space-y-4 pb-4 md:pb-0">
+      <h3 className="mb-3 text-xl font-medium">Translation History</h3>
+
+      <form>
+        <label
+          htmlFor="translation_search"
+          className="text-slate-600 text-sm"
+        >
+          Search translations
+        </label>
+        <Input
+          id="translation_search"
+          type="search"
+          placeholder="Search for a word or a translation..."
+        />
+      </form>
+
+      <div className="border rounded overflow-y-auto h-96 p-4 bg-background">
+        <TranslationSkeletonCard />
+        <TranslationSkeletonCard />
+        <TranslationSkeletonCard />
+      </div>
+    </div>
+  )
+}
+
+export function TranslationSkeletonCard() {
+  return (
+    <div className="shadow-md rounded p-4">
+      <div className="text-xl">
+        <div className="flex items-center gap-2">
+          <span>
+            <Skeleton className="w-16 h-3" />
+          </span>
+          {' = '}
+          <span>
+            <Skeleton className="w-16 h-3" />
+          </span>
+        </div>
+
+        <span className="text-muted-foreground">
+          <Skeleton className="w-60 h-3" />
+        </span>
+      </div>
+
+      <div>
+        <ul className="space-y-4 mt-4">
+          <li className="flex flex-col gap-2">
+            <Skeleton className="w-32 h-2" />
+            <Skeleton className="w-36 h-2" />
+          </li>
+
+          <li className="flex flex-col gap-2">
+            <Skeleton className="w-32 h-2" />
+            <Skeleton className="w-36 h-2" />
+          </li>
+
+          <li className="flex flex-col gap-2">
+            <Skeleton className="w-32 h-2" />
+            <Skeleton className="w-36 h-2" />
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/components/translations-history-skeleton.tsx
+++ b/components/translations-history-skeleton.tsx
@@ -1,5 +1,5 @@
-import { Input } from "./ui/input";
-import { Skeleton } from "./ui/skeleton";
+import { Input } from './ui/input';
+import { Skeleton } from './ui/skeleton';
 
 export async function TranslationsHistorySkeleton() {
   return (
@@ -7,10 +7,7 @@ export async function TranslationsHistorySkeleton() {
       <h3 className="mb-3 text-xl font-medium">Translation History</h3>
 
       <form>
-        <label
-          htmlFor="translation_search"
-          className="text-slate-600 text-sm"
-        >
+        <label htmlFor="translation_search" className="text-slate-600 text-sm">
           Search translations
         </label>
         <Input
@@ -26,7 +23,7 @@ export async function TranslationsHistorySkeleton() {
         <TranslationSkeletonCard />
       </div>
     </div>
-  )
+  );
 }
 
 export function TranslationSkeletonCard() {
@@ -67,5 +64,5 @@ export function TranslationSkeletonCard() {
         </ul>
       </div>
     </div>
-  )
+  );
 }

--- a/components/translations-history.tsx
+++ b/components/translations-history.tsx
@@ -1,0 +1,86 @@
+import { checkUserAction } from "@/actions/auth/check-user";
+import { prismaClient } from "@/lib/prisma-client";
+import { Input } from "./ui/input";
+
+export async function TranslationsHistory() {
+  const user = await checkUserAction();
+
+  const translations = await prismaClient.translations.findMany({
+    where: {
+      userId: user.id,
+    },
+    include: {
+      phrases: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+
+  return (
+    <div className="h-full space-y-4 pb-4 md:pb-0">
+      <h3 className="mb-3 text-xl font-medium">Translation History ({translations.length})</h3>
+
+      <form>
+        <label
+          htmlFor="translation_search"
+          className="text-slate-600 text-sm"
+        >
+          Search translations
+        </label>
+        <Input
+          id="translation_search"
+          type="search"
+          placeholder="Search for a word or a translation..."
+        />
+      </form>
+
+      <div className="border rounded overflow-y-auto h-96 p-4 bg-background">
+        {translations.length === 0 ? (
+          <p className="text-slate-400 text-center py-10">
+            No translations found.
+          </p>
+        ) : (
+          translations.map((translation) => (
+            <div key={translation.id} className="shadow-md rounded p-4">
+              <div className="text-xl">
+                <div className="flex items-center gap-2">
+                  <span className="font-bold">
+                    {translation.targetWord} ({translation.languageFrom})
+                  </span>
+                  {' = '}
+                  <span className="font-bold">
+                    {translation.translatedWord} ({translation.languageTo})
+                  </span>
+                </div>
+
+                <span className="text-muted-foreground">
+                  {translation.createdAt.toLocaleDateString('en', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  })}
+                </span>
+              </div>
+
+              <div>
+                <ul className="space-y-2 mt-4">
+                  {translation.phrases.map((phrase) => (
+                    <li key={phrase.id} className="flex flex-col">
+                      <span className="font-bold">{phrase.content}</span>
+                      <span className="text-muted-foreground">
+                        {phrase.translatedContent}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/translations-history.tsx
+++ b/components/translations-history.tsx
@@ -1,6 +1,6 @@
-import { checkUserAction } from "@/actions/auth/check-user";
-import { prismaClient } from "@/lib/prisma-client";
-import { Input } from "./ui/input";
+import { checkUserAction } from '@/actions/auth/check-user';
+import { prismaClient } from '@/lib/prisma-client';
+import { Input } from './ui/input';
 
 export async function TranslationsHistory() {
   const user = await checkUserAction();
@@ -19,13 +19,12 @@ export async function TranslationsHistory() {
 
   return (
     <div className="h-full space-y-4 pb-4 md:pb-0">
-      <h3 className="mb-3 text-xl font-medium">Translation History ({translations.length})</h3>
+      <h3 className="mb-3 text-xl font-medium">
+        Translation History ({translations.length})
+      </h3>
 
       <form>
-        <label
-          htmlFor="translation_search"
-          className="text-slate-600 text-sm"
-        >
+        <label htmlFor="translation_search" className="text-slate-600 text-sm">
           Search translations
         </label>
         <Input
@@ -82,5 +81,5 @@ export async function TranslationsHistory() {
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Skeleton({
   className,
@@ -6,10 +6,10 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      className={cn('animate-pulse rounded-md bg-primary/10', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };


### PR DESCRIPTION
## Done
- Created `Skeleton` component with shadcn
- Componentized `translations history` section to make the codebase more readable
- Created `TranslationsHistorySkeleton` component to use as a fallback
- Componentized `Header` section to make the codebase more readable
- Adjusted home page to use the created components and make only necessary queries
- Added `total translations count` right after `Translations History` text

## Preview
[Gravação de tela de 12-03-2025 15:42:33.webm](https://github.com/user-attachments/assets/7a30819f-9a57-4118-b75f-510de6ef80a7)
