### PR TITLE
Adjusts `word already translated` verification using `prisma insensitive` mode

### DIFF
--- a/models/gemini.ts
+++ b/models/gemini.ts
@@ -90,7 +90,10 @@ async function generateTranslation(wordToTranslate: string) {
   async function getTranslation() {
     const translation = await prismaClient.translations.findFirst({
       where: {
-        targetWord: wordToTranslate,
+        targetWord: {
+          equals: wordToTranslate,
+          mode: 'insensitive',
+        },
       },
       include: {
         phrases: true,

--- a/prisma/migrations/20250314173130_add_on_delete_cascade_clause_in_translations_phrases_table/migration.sql
+++ b/prisma/migrations/20250314173130_add_on_delete_cascade_clause_in_translations_phrases_table/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "TranslationPhrases" DROP CONSTRAINT "TranslationPhrases_translation_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "TranslationPhrases" ADD CONSTRAINT "TranslationPhrases_translation_id_fkey" FOREIGN KEY ("translation_id") REFERENCES "translations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,5 +44,5 @@ model TranslationPhrases {
   createdAt         DateTime @default(now()) @map("created_at")
   updatedAt         DateTime @updatedAt @map("updated_at")
 
-  translation Translations @relation(fields: [translationId], references: [id])
+  translation Translations @relation(fields: [translationId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
## Done
- Added `ON DELETE CASCADE` clause to `TranslationPhrases table`
- Used `case insensitive` prisma search mode to find words already translated

## Preview
[Gravação de tela de 14-03-2025 14:39:31.webm](https://github.com/user-attachments/assets/5fb93d19-33f9-4dbd-b7a1-b4e84472202f)
