### PR TITLE
Refactor/small adjustments

### DIFF
--- a/app/(private)/dashboard/actions.ts
+++ b/app/(private)/dashboard/actions.ts
@@ -1,14 +1,14 @@
-"use server";
+'use server';
 
-import { checkUserAction } from "@/actions/auth/check-user";
-import { GeminiServiceError } from "@/errors/gemini-service-error";
-import { InvalidWordError } from "@/errors/invalid-word-error";
-import { ParseTextError } from "@/errors/parse-text-error";
-import { ParseZodError } from "@/errors/parse-zod-error";
-import { prismaClient } from "@/lib/prisma-client";
-import { gemini } from "@/models/gemini";
-import { revalidatePath } from "next/cache";
-import { z } from "zod";
+import { checkUserAction } from '@/actions/auth/check-user';
+import { GeminiServiceError } from '@/errors/gemini-service-error';
+import { InvalidWordError } from '@/errors/invalid-word-error';
+import { ParseTextError } from '@/errors/parse-text-error';
+import { ParseZodError } from '@/errors/parse-zod-error';
+import { prismaClient } from '@/lib/prisma-client';
+import { gemini } from '@/models/gemini';
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
 
 export type TranslationResponse = {
   ok: boolean;
@@ -20,7 +20,7 @@ export type TranslationResponse = {
 
 const defaultErrorObject = {
   ok: false,
-  error: "Something went wrong while generating the translation.",
+  error: 'Something went wrong while generating the translation.',
 };
 
 const schema = z.object({
@@ -29,9 +29,9 @@ const schema = z.object({
 
 export async function generateTranslationAction(
   _prevState: unknown,
-  formData: FormData
+  formData: FormData,
 ): Promise<TranslationResponse> {
-  const wordToTranslate = formData.get("word_to_translate") as string;
+  const wordToTranslate = formData.get('word_to_translate') as string;
 
   const parsedData = schema.safeParse({ word_to_translate: wordToTranslate });
 
@@ -40,7 +40,7 @@ export async function generateTranslationAction(
       ok: false,
       error: parsedData.error.errors[0].message,
       word_to_translate: wordToTranslate,
-      module: "parse-zod",
+      module: 'parse-zod',
     };
   }
 
@@ -53,7 +53,7 @@ export async function generateTranslationAction(
           userId: user.id,
           targetWord: {
             equals: parsedData.data.word_to_translate,
-            mode: "insensitive",
+            mode: 'insensitive',
           },
         },
       });
@@ -70,8 +70,8 @@ export async function generateTranslationAction(
     await prismaClient.translations.create({
       data: {
         userId: user.id,
-        languageFrom: "en",
-        languageTo: "pt",
+        languageFrom: 'en',
+        languageTo: 'pt',
         targetWord: wordToTranslate,
         translatedWord: result.output,
         phrases: {
@@ -95,7 +95,7 @@ export async function generateTranslationAction(
       },
     });
 
-    revalidatePath("/");
+    revalidatePath('/');
 
     return {
       ok: true,
@@ -104,7 +104,7 @@ export async function generateTranslationAction(
     if (error instanceof GeminiServiceError) {
       return {
         ...defaultErrorObject,
-        module: "gemini",
+        module: 'gemini',
         word_to_translate: wordToTranslate,
       };
     }
@@ -112,16 +112,16 @@ export async function generateTranslationAction(
     if (error instanceof InvalidWordError) {
       return {
         ok: false,
-        error: "The word you entered is invalid. Please try again.",
+        error: 'The word you entered is invalid. Please try again.',
         word_to_translate: wordToTranslate,
-        module: "invalid-word",
+        module: 'invalid-word',
       };
     }
 
     if (error instanceof ParseTextError) {
       return {
         ...defaultErrorObject,
-        module: "parse-text",
+        module: 'parse-text',
         word_to_translate: wordToTranslate,
       };
     }
@@ -129,7 +129,7 @@ export async function generateTranslationAction(
     if (error instanceof ParseZodError) {
       return {
         ...defaultErrorObject,
-        module: "parse-zod",
+        module: 'parse-zod',
         word_to_translate: wordToTranslate,
       };
     }
@@ -146,14 +146,14 @@ export async function findTranslationsAction(searchTerm: string) {
       userId: user.id,
       targetWord: {
         contains: searchTerm,
-        mode: "insensitive",
+        mode: 'insensitive',
       },
     },
     include: {
       phrases: true,
     },
     orderBy: {
-      createdAt: "desc",
+      createdAt: 'desc',
     },
   });
 

--- a/app/(private)/dashboard/actions.ts
+++ b/app/(private)/dashboard/actions.ts
@@ -1,14 +1,14 @@
-'use server';
+"use server";
 
-import { checkUserAction } from '@/actions/auth/check-user';
-import { GeminiServiceError } from '@/errors/gemini-service-error';
-import { InvalidWordError } from '@/errors/invalid-word-error';
-import { ParseTextError } from '@/errors/parse-text-error';
-import { ParseZodError } from '@/errors/parse-zod-error';
-import { prismaClient } from '@/lib/prisma-client';
-import { gemini } from '@/models/gemini';
-import { revalidatePath } from 'next/cache';
-import { z } from 'zod';
+import { checkUserAction } from "@/actions/auth/check-user";
+import { GeminiServiceError } from "@/errors/gemini-service-error";
+import { InvalidWordError } from "@/errors/invalid-word-error";
+import { ParseTextError } from "@/errors/parse-text-error";
+import { ParseZodError } from "@/errors/parse-zod-error";
+import { prismaClient } from "@/lib/prisma-client";
+import { gemini } from "@/models/gemini";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
 
 export type TranslationResponse = {
   ok: boolean;
@@ -20,7 +20,7 @@ export type TranslationResponse = {
 
 const defaultErrorObject = {
   ok: false,
-  error: 'Something went wrong while generating the translation.',
+  error: "Something went wrong while generating the translation.",
 };
 
 const schema = z.object({
@@ -29,9 +29,9 @@ const schema = z.object({
 
 export async function generateTranslationAction(
   _prevState: unknown,
-  formData: FormData,
+  formData: FormData
 ): Promise<TranslationResponse> {
-  const wordToTranslate = formData.get('word_to_translate') as string;
+  const wordToTranslate = formData.get("word_to_translate") as string;
 
   const parsedData = schema.safeParse({ word_to_translate: wordToTranslate });
 
@@ -40,7 +40,7 @@ export async function generateTranslationAction(
       ok: false,
       error: parsedData.error.errors[0].message,
       word_to_translate: wordToTranslate,
-      module: 'parse-zod',
+      module: "parse-zod",
     };
   }
 
@@ -53,7 +53,7 @@ export async function generateTranslationAction(
           userId: user.id,
           targetWord: {
             equals: parsedData.data.word_to_translate,
-            mode: 'insensitive',
+            mode: "insensitive",
           },
         },
       });
@@ -70,8 +70,8 @@ export async function generateTranslationAction(
     await prismaClient.translations.create({
       data: {
         userId: user.id,
-        languageFrom: 'en',
-        languageTo: 'pt',
+        languageFrom: "en",
+        languageTo: "pt",
         targetWord: wordToTranslate,
         translatedWord: result.output,
         phrases: {
@@ -95,7 +95,7 @@ export async function generateTranslationAction(
       },
     });
 
-    revalidatePath('/');
+    revalidatePath("/");
 
     return {
       ok: true,
@@ -104,7 +104,7 @@ export async function generateTranslationAction(
     if (error instanceof GeminiServiceError) {
       return {
         ...defaultErrorObject,
-        module: 'gemini',
+        module: "gemini",
         word_to_translate: wordToTranslate,
       };
     }
@@ -112,16 +112,16 @@ export async function generateTranslationAction(
     if (error instanceof InvalidWordError) {
       return {
         ok: false,
-        error: 'The word you entered is invalid. Please try again.',
+        error: "The word you entered is invalid. Please try again.",
         word_to_translate: wordToTranslate,
-        module: 'invalid-word',
+        module: "invalid-word",
       };
     }
 
     if (error instanceof ParseTextError) {
       return {
         ...defaultErrorObject,
-        module: 'parse-text',
+        module: "parse-text",
         word_to_translate: wordToTranslate,
       };
     }
@@ -129,7 +129,7 @@ export async function generateTranslationAction(
     if (error instanceof ParseZodError) {
       return {
         ...defaultErrorObject,
-        module: 'parse-zod',
+        module: "parse-zod",
         word_to_translate: wordToTranslate,
       };
     }
@@ -146,14 +146,14 @@ export async function findTranslationsAction(searchTerm: string) {
       userId: user.id,
       targetWord: {
         contains: searchTerm,
-        mode: 'insensitive',
+        mode: "insensitive",
       },
     },
     include: {
       phrases: true,
     },
     orderBy: {
-      createdAt: 'desc',
+      createdAt: "desc",
     },
   });
 

--- a/app/(private)/dashboard/page.tsx
+++ b/app/(private)/dashboard/page.tsx
@@ -51,7 +51,7 @@ export default async function Page() {
 
   return (
     <main className="flex flex-col px-6 py-12 gap-4">
-      <div className="flex flex-col sm:flex-row gap-4">
+      <div className="flex flex-col md:flex-row gap-4">
         <div className="rounded w-full xl:w-1/2 flex flex-col">
           <h2 className="mb-3  text-xl font-medium">Translate a word</h2>
 

--- a/app/(private)/dashboard/page.tsx
+++ b/app/(private)/dashboard/page.tsx
@@ -5,31 +5,10 @@ import { TranslationsHistorySkeleton } from '@/components/translations-history-s
 import { prismaClient } from '@/lib/prisma-client';
 import { Suspense } from 'react';
 
-const now = new Date();
+const date = new Date().toISOString().split('T')[0];
 
-const startOfToday = new Date(
-  Date.UTC(
-    now.getUTCFullYear(),
-    now.getUTCMonth(),
-    now.getUTCDate(),
-    0,
-    0,
-    0,
-    0,
-  ),
-);
-
-const endOfToday = new Date(
-  Date.UTC(
-    now.getUTCFullYear(),
-    now.getUTCMonth(),
-    now.getUTCDate(),
-    23,
-    59,
-    59,
-    999,
-  ),
-);
+const startOfToday = new Date(`${date}T00:00:00.000Z`);
+const endOfToday = new Date(`${date}T23:59:59.999Z`);
 
 export default async function Page() {
   const user = await checkUserAction();

--- a/app/(private)/dashboard/page.tsx
+++ b/app/(private)/dashboard/page.tsx
@@ -36,6 +36,19 @@ export default async function Page() {
     },
   });
 
+  const randomWordsInEnglishToTranslate = [
+    'Smart Contract',
+    'Decentralized',
+    'Cryptocurrency',
+    'Smart Translator',
+    'Artificial Intelligence',
+    'Machine Learning',
+  ];
+
+  const randomPlaceHolderIndex = Math.floor(
+    Math.random() * randomWordsInEnglishToTranslate.length,
+  );
+
   return (
     <main className="flex flex-col px-6 py-12 gap-4">
       <div className="flex flex-col sm:flex-row gap-4">
@@ -44,6 +57,7 @@ export default async function Page() {
 
           <GenerateTranslationForm
             disabled={todayTranslations.length >= MAX_TRANSLATIONS_PER_DAY}
+            label={randomWordsInEnglishToTranslate[randomPlaceHolderIndex]}
           />
 
           <div className="flex gap-2 mt-4">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,76 +1,61 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 221.2 83.2% 53.3%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 10% 3.9%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221.2 83.2% 53.3%;
+    --radius: 0.5rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
   }
+
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-  }
-}
-@layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
               generates related phrases to help you learn languages naturally
             </p>
 
-            <div className="space-x-4">
+            <div className="flex gap-4 flex-col sm:flex-row">
               <Button size="lg" asChild>
                 <Link href="/auth/sign-up">Get Started Free</Link>
               </Button>

--- a/components/generate-translation-form.tsx
+++ b/components/generate-translation-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { generateTranslationAction } from '@/app/actions';
+import { generateTranslationAction } from '@/app/(private)/dashboard/actions';
+import { Sparkles } from 'lucide-react';
 import { useActionState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { Button } from './ui/button';
@@ -8,10 +9,12 @@ import { Input } from './ui/input';
 
 type GenerateTranslationFormProps = {
   disabled?: boolean;
+  label: string;
 };
 
 export function GenerateTranslationForm({
   disabled,
+  label,
 }: GenerateTranslationFormProps) {
   const [state, action, isPending] = useActionState(
     generateTranslationAction,
@@ -46,13 +49,13 @@ export function GenerateTranslationForm({
   return (
     <form action={action} className="space-y-2 w-full xl:w-1/2 min-w-40">
       <label htmlFor="word_to_translate" className="text-slate-600 text-sm">
-        Enter a word in English
+        Type an English word/term (20 characters max)
       </label>
       <Input
         required
         id="word_to_translate"
         disabled={disabled}
-        placeholder="Word"
+        placeholder={label}
         name="word_to_translate"
         defaultValue={
           state?.module === 'invalid-word' ? '' : state?.word_to_translate
@@ -66,6 +69,8 @@ export function GenerateTranslationForm({
       )}
 
       <Button disabled={isPending || disabled}>
+        <Sparkles className="size-4" />
+
         {isPending ? 'Generating Translation...' : 'Generate Translation'}
       </Button>
     </form>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,4 +1,5 @@
 import { logout } from '@/actions/auth/logout';
+import { prismaClient } from '@/lib/prisma-client';
 import type { Users as User } from '@prisma/client';
 import { Globe, LogOutIcon, User2Icon } from 'lucide-react';
 import Link from 'next/link';
@@ -38,36 +39,49 @@ export function Header({ user }: HeaderProps) {
     );
   }
 
-  function UserOptions() {
+  async function UserOptions() {
     if (!user) return null;
 
+    const userPlan = await prismaClient.plans.findFirst({
+      where: {
+        id: user.planId,
+      },
+    });
+
     return (
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button>
-            <MenuIcon />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-fit">
-          <div className="space-y-2 flex flex-col">
-            <span>Hello, {user.name}</span>
+      <div className="flex items-center gap-2">
+        <span className="hidden md:block border rounded-full text-xs px-2 py-1 text-muted-foreground">
+          {userPlan?.name} Plan: {userPlan?.translationsLimit} Translations per
+          day
+        </span>
 
-            <Button asChild variant="ghost">
-              <Link href="/profile">
-                <User2Icon />
-                Profile
-              </Link>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button>
+              <MenuIcon />
             </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-fit">
+            <div className="space-y-2 flex flex-col">
+              <span>Hello, {user.name}</span>
 
-            <form action={logout}>
-              <Button className="w-full" variant="destructive">
-                <LogOutIcon />
-                Logout
+              <Button asChild variant="ghost">
+                <Link href="/profile">
+                  <User2Icon />
+                  Profile
+                </Link>
               </Button>
-            </form>
-          </div>
-        </PopoverContent>
-      </Popover>
+
+              <form action={logout}>
+                <Button className="w-full" variant="destructive">
+                  <LogOutIcon />
+                  Logout
+                </Button>
+              </form>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
     );
   }
 }

--- a/components/sign-in.tsx
+++ b/components/sign-in.tsx
@@ -15,6 +15,7 @@ import { signInSchema } from '@/types/sign-in';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
@@ -33,6 +34,7 @@ export function SignInForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<'div'>) {
+  const [isLoading, setIsLoading] = useState(false);
   const route = useRouter();
 
   const form = useForm<FormData>({
@@ -44,6 +46,7 @@ export function SignInForm({
   });
 
   async function onSubmit(data: FormData) {
+    setIsLoading(true);
     const { error } = await signInAction(data);
 
     if (error) {
@@ -52,6 +55,7 @@ export function SignInForm({
     }
 
     toast.success('User logged in successfully');
+    setIsLoading(false);
     route.push('/dashboard');
   }
 
@@ -105,7 +109,7 @@ export function SignInForm({
                     </FormItem>
                   )}
                 />
-                <Button type="submit" className="w-full">
+                <Button disabled={isLoading} type="submit" className="w-full">
                   Login
                 </Button>
               </div>

--- a/components/sign-up.tsx
+++ b/components/sign-up.tsx
@@ -15,6 +15,7 @@ import { signUpSchema } from '@/types/sign-up';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
@@ -33,6 +34,7 @@ export function SignUpForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<'div'>) {
+  const [isLoading, setIsLoading] = useState(false);
   const route = useRouter();
 
   const form = useForm<FormData>({
@@ -45,6 +47,7 @@ export function SignUpForm({
   });
 
   async function onSubmit(data: FormData) {
+    setIsLoading(true);
     const { error, message } = await signUpAction(data);
 
     if (error) {
@@ -53,6 +56,7 @@ export function SignUpForm({
     }
 
     toast.success(message);
+    setIsLoading(false);
     route.push('/auth/sign-in');
   }
 
@@ -117,7 +121,7 @@ export function SignUpForm({
                     </FormItem>
                   )}
                 />
-                <Button type="submit" className="w-full">
+                <Button disabled={isLoading} type="submit" className="w-full">
                   Register
                 </Button>
               </div>

--- a/components/translations-history/content.tsx
+++ b/components/translations-history/content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { findTranslationsAction } from '@/app/actions';
+import { findTranslationsAction } from '@/app/(private)/dashboard/actions';
 import type { TranslationPhrases, Translations } from '@prisma/client';
 import { Loader2Icon } from 'lucide-react';
 import { useState } from 'react';

--- a/models/auth.ts
+++ b/models/auth.ts
@@ -25,11 +25,19 @@ async function signUp(input: SignUpProps) {
   const SALT = 10;
   const hashedPassword = await bcrypt.hash(password, SALT);
 
+  const availablePlan = await prismaClient.plans.findFirst({
+    where: {
+      active: true,
+      name: 'Free',
+    },
+  });
+
   await prismaClient.users.create({
     data: {
       email,
       name,
       password: hashedPassword,
+      planId: availablePlan!.id,
     },
   });
 

--- a/prisma/migrations/20250320011138_create_plans_table_and_relates_with_user/migration.sql
+++ b/prisma/migrations/20250320011138_create_plans_table_and_relates_with_user/migration.sql
@@ -1,0 +1,47 @@
+/*
+  Warnings:
+
+  - You are about to drop the `TranslationPhrases` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `planId` to the `users` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "TranslationPhrases" DROP CONSTRAINT "TranslationPhrases_translation_id_fkey";
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "planId" UUID NOT NULL;
+
+-- DropTable
+DROP TABLE "TranslationPhrases";
+
+-- CreateTable
+CREATE TABLE "translation_phrases" (
+    "id" UUID NOT NULL,
+    "translation_id" UUID NOT NULL,
+    "content" TEXT NOT NULL,
+    "translated_content" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "translation_phrases_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "plans" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "price" DOUBLE PRECISION NOT NULL,
+    "translations_limit" INTEGER NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "plans_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "plans_name_key" ON "plans"("name");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_planId_fkey" FOREIGN KEY ("planId") REFERENCES "plans"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "translation_phrases" ADD CONSTRAINT "translation_phrases_translation_id_fkey" FOREIGN KEY ("translation_id") REFERENCES "translations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,9 @@ model Users {
   password  String
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
+  planId    String   @db.Uuid
+
+  plan Plans @relation(fields: [planId], references: [id], onDelete: Cascade)
 
   translations Translations[]
 
@@ -45,4 +48,18 @@ model TranslationPhrases {
   updatedAt         DateTime @updatedAt @map("updated_at")
 
   translation Translations @relation(fields: [translationId], references: [id], onDelete: Cascade)
+
+  @@map("translation_phrases")
+}
+
+model Plans {
+  id                String  @id @default(uuid()) @db.Uuid
+  name              String  @unique
+  price             Float
+  translationsLimit Int     @map("translations_limit")
+  active            Boolean @default(true)
+
+  user Users[]
+
+  @@map("plans")
 }


### PR DESCRIPTION
## Done
- Moved `actions` file to `/dashboard` folder
- Changed `globals.css` with another color scheme
- Changed the approach of handling `today translations`
- Adjusted `actions` file by running `pnpm biome:fix` command
- Created mechanism to use random inupt labels
- Updated seed script to populate `plans table`
- Added `user plan` information on header component
- Adjustes `auth.signUp` method to relate user with a default plan
- Adjusted `sign-in` and `sign-up` pages loading state
- Adjusted button display in `landing page`

## Preview
[Gravação de tela de 19-03-2025 22:24:02.webm](https://github.com/user-attachments/assets/ef86f57f-d3d2-49ad-a270-055231323d8c)
