### PR TITLE
Feat/final language adjustments

### DIFF
--- a/app/(public)/auth/layout.tsx
+++ b/app/(public)/auth/layout.tsx
@@ -1,3 +1,4 @@
+import { getAppLanguageAction } from '@/app/actions';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 
@@ -5,14 +6,16 @@ type Props = {
   children: ReactNode;
 };
 
-export default function Layout({ children }: Props) {
+export default async function Layout({ children }: Props) {
+  const language = await getAppLanguageAction();
+
   return (
     <div className="h-full grid place-items-center relative">
       <Link
         href="/"
         className="hover:underline transition-all absolute top-6 left-6"
       >
-        Back to home
+        {language === 'pt-br' ? 'Voltar para o início' : 'Back to home'}
       </Link>
       {children}
     </div>

--- a/app/(public)/auth/sign-in/page.tsx
+++ b/app/(public)/auth/sign-in/page.tsx
@@ -1,5 +1,12 @@
+import { getAppLanguageAction } from '@/app/actions';
 import { SignInForm } from '@/components/sign-in';
+import { getLanguageContext } from '@/config/app-language-context';
 
-export default function SignIn() {
-  return <SignInForm />;
+export default async function SignIn() {
+  const language = await getAppLanguageAction();
+  const appLanguageContext = getLanguageContext(language);
+
+  return (
+    <SignInForm appLanguageContext={appLanguageContext} language={language} />
+  );
 }

--- a/app/(public)/auth/sign-up/page.tsx
+++ b/app/(public)/auth/sign-up/page.tsx
@@ -1,5 +1,12 @@
+import { getAppLanguageAction } from '@/app/actions';
 import { SignUpForm } from '@/components/sign-up';
+import { getLanguageContext } from '@/config/app-language-context';
 
-export default function SignIn() {
-  return <SignUpForm />;
+export default async function SignIn() {
+  const language = await getAppLanguageAction();
+  const appLanguageContext = getLanguageContext(language);
+
+  return (
+    <SignUpForm appLanguageContext={appLanguageContext} language={language} />
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,7 +101,7 @@ export default async function Page() {
 
           <div className="flex flex-col md:flex-row items-center justify-center gap-10">
             {projectConstants.plans[language].map((plan) => (
-              <PlanCard key={plan.title} plan={plan} />
+              <PlanCard key={plan.title} plan={plan} language={language} />
             ))}
           </div>
         </section>

--- a/components/change-language-button.tsx
+++ b/components/change-language-button.tsx
@@ -3,7 +3,7 @@
 import { setAppLanguageAction } from '@/app/actions';
 import { cn } from '@/lib/utils';
 import { LanguagesIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from './ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 
@@ -13,12 +13,25 @@ type ChangeLanguageButtonProps = {
 
 export function ChangeLanguageButton({ className }: ChangeLanguageButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isPulsing, setIsPulsing] = useState(true);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setIsPulsing(false);
+    }, 4000);
+
+    return () => clearTimeout(timeout);
+  }, []);
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <Button
         title="Change Language"
-        className={cn('fixed bottom-2 right-2 size-10 rounded-full', className)}
+        className={cn(
+          'fixed bottom-2 right-2 size-10 rounded-full backdrop-blur ease-in-out',
+          isPulsing && 'animate-pulse',
+          className,
+        )}
         asChild
       >
         <PopoverTrigger>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -55,11 +55,22 @@ export async function Header({ user }: HeaderProps) {
       },
     });
 
+    function buildPlanLabel() {
+      if (!userPlan) return '';
+
+      if (language === 'pt-br') {
+        return `Plano ${userPlan.name}: ${userPlan.translationsLimit} traduções por dia`;
+      }
+
+      return `${userPlan.name} Plan: ${userPlan.translationsLimit} translations per day`;
+    }
+
+    const formattedPlanLabel = buildPlanLabel();
+
     return (
       <div className="flex items-center gap-2">
         <span className="hidden md:block border rounded-full text-xs px-2 py-1 text-muted-foreground">
-          {userPlan?.name} Plan: {userPlan?.translationsLimit} Translations per
-          day
+          {formattedPlanLabel}
         </span>
 
         <Popover>
@@ -70,19 +81,21 @@ export async function Header({ user }: HeaderProps) {
           </PopoverTrigger>
           <PopoverContent className="w-fit">
             <div className="space-y-2 flex flex-col">
-              <span>Hello, {user.name}</span>
+              <span>
+                {appLanguageContext.userOptions.hello}, {user.name}
+              </span>
 
               <Button asChild variant="ghost">
                 <Link href="/profile">
                   <User2Icon />
-                  Profile
+                  {appLanguageContext.userOptions.profile}
                 </Link>
               </Button>
 
               <form action={logout}>
                 <Button className="w-full" variant="destructive">
                   <LogOutIcon />
-                  Logout
+                  {appLanguageContext.userOptions.signOut}
                 </Button>
               </form>
             </div>

--- a/components/plan-card.tsx
+++ b/components/plan-card.tsx
@@ -1,4 +1,4 @@
-import type { Plan } from '@/config/constants';
+import type { AvailableLanguages, Plan } from '@/config/constants';
 import { cn } from '@/lib/utils';
 import { Check, X } from 'lucide-react';
 import Link from 'next/link';
@@ -7,9 +7,10 @@ import { Card, CardHeader, CardTitle } from './ui/card';
 
 type PlanCardProps = {
   plan: Plan;
+  language: AvailableLanguages;
 };
 
-export function PlanCard({ plan }: PlanCardProps) {
+export function PlanCard({ plan, language }: PlanCardProps) {
   return (
     <Card
       className={cn(
@@ -21,12 +22,10 @@ export function PlanCard({ plan }: PlanCardProps) {
         <CardTitle className="text-3xl font-medium">{plan.title}</CardTitle>
 
         <span>
-          <strong className="text-xl">
-            {plan.currency === 'brl' ? 'R$' : '$'} {plan.price}
-          </strong>
+          <strong className="text-xl">$ {plan.usdPrice}</strong>
           <span className="text-muted-foreground">
             {' '}
-            / {plan.currency === 'brl' ? 'mensal' : 'month'}
+            / {language === 'pt-br' ? 'mensal' : 'month'}
           </span>
         </span>
       </CardHeader>
@@ -58,7 +57,7 @@ export function PlanCard({ plan }: PlanCardProps) {
           asChild={plan.status.available}
         >
           <Link href="/auth/sign-up" aria-disabled={!plan.status.available}>
-            {plan.currency === 'brl' ? 'Começar' : 'Get Started'}
+            {language === 'pt-br' ? 'Começar' : 'Get Started'}
           </Link>
         </Button>
       </div>

--- a/components/sign-in.tsx
+++ b/components/sign-in.tsx
@@ -10,12 +10,14 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import type { AppLanguageContext } from '@/config/app-language-context';
+import type { AvailableLanguages } from '@/config/constants';
 import { cn } from '@/lib/utils';
 import { signInSchema } from '@/types/sign-in';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { type ComponentPropsWithRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
@@ -30,10 +32,17 @@ import {
 
 type FormData = z.infer<typeof signInSchema>;
 
+type SignInFormProps = ComponentPropsWithRef<'div'> & {
+  appLanguageContext: AppLanguageContext;
+  language: AvailableLanguages;
+};
+
 export function SignInForm({
+  appLanguageContext,
+  language,
   className,
   ...props
-}: React.ComponentPropsWithoutRef<'div'>) {
+}: SignInFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const route = useRouter();
 
@@ -55,7 +64,7 @@ export function SignInForm({
       return;
     }
 
-    toast.success('User logged in successfully');
+    toast.success(appLanguageContext.auth.signedInSuccessfully);
     setIsLoading(false);
     route.push('/dashboard');
   }
@@ -64,9 +73,11 @@ export function SignInForm({
     <div className={cn('flex flex-col gap-6', className)} {...props}>
       <Card>
         <CardHeader>
-          <CardTitle className="text-2xl">Sign-In</CardTitle>
+          <CardTitle className="text-2xl">
+            {appLanguageContext.signInLabel}
+          </CardTitle>
           <CardDescription>
-            Enter your email below to login to your account
+            {appLanguageContext.auth.signInDescription}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -97,7 +108,9 @@ export function SignInForm({
                   name="password"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Password</FormLabel>
+                      <FormLabel>
+                        {language === 'en' ? 'Password' : 'Senha'}
+                      </FormLabel>
                       <FormControl>
                         <Input
                           type="password"
@@ -111,16 +124,16 @@ export function SignInForm({
                   )}
                 />
                 <Button disabled={isLoading} type="submit" className="w-full">
-                  Login
+                  {appLanguageContext.signInLabel}
                 </Button>
               </div>
               <div className="mt-4 text-center text-sm">
-                Don&apos;t have an account?{' '}
+                {appLanguageContext.auth.doNotHaveAccount}{' '}
                 <Link
                   href="/auth/sign-up"
                   className="underline underline-offset-4"
                 >
-                  Sign up
+                  {appLanguageContext.signUpLabel}
                 </Link>
               </div>
             </form>

--- a/components/sign-up.tsx
+++ b/components/sign-up.tsx
@@ -10,12 +10,14 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import type { AppLanguageContext } from '@/config/app-language-context';
+import type { AvailableLanguages } from '@/config/constants';
 import { cn } from '@/lib/utils';
 import { signUpSchema } from '@/types/sign-up';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { type ComponentPropsWithRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
@@ -30,10 +32,17 @@ import {
 
 type FormData = z.infer<typeof signUpSchema>;
 
+type SigUpFormProps = ComponentPropsWithRef<'div'> & {
+  appLanguageContext: AppLanguageContext;
+  language: AvailableLanguages;
+};
+
 export function SignUpForm({
+  appLanguageContext,
+  language,
   className,
   ...props
-}: React.ComponentPropsWithoutRef<'div'>) {
+}: SigUpFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const route = useRouter();
 
@@ -65,9 +74,11 @@ export function SignUpForm({
     <div className={cn('flex flex-col gap-6', className)} {...props}>
       <Card>
         <CardHeader>
-          <CardTitle className="text-2xl">Sign-Up</CardTitle>
+          <CardTitle className="text-2xl">
+            {appLanguageContext.signUpLabel}
+          </CardTitle>
           <CardDescription>
-            Enter your email below to register to your account
+            {appLanguageContext.auth.signUpDescription}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -79,7 +90,9 @@ export function SignUpForm({
                   name="name"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Username</FormLabel>
+                      <FormLabel>
+                        {language === 'en' ? 'Username' : 'Nome de usuário'}
+                      </FormLabel>
                       <FormControl>
                         <Input required placeholder="Jonh Doe" {...field} />
                       </FormControl>
@@ -109,7 +122,9 @@ export function SignUpForm({
                   name="password"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Password</FormLabel>
+                      <FormLabel>
+                        {language === 'en' ? 'Password' : 'Senha'}
+                      </FormLabel>
                       <FormControl>
                         <Input
                           type="password"
@@ -123,16 +138,16 @@ export function SignUpForm({
                   )}
                 />
                 <Button disabled={isLoading} type="submit" className="w-full">
-                  Register
+                  {appLanguageContext.signUpLabel}
                 </Button>
               </div>
               <div className="mt-4 text-center text-sm">
-                Already have an account?{' '}
+                {appLanguageContext.auth.alreadyHaveAccount}{' '}
                 <Link
                   href="/auth/sign-in"
                   className="underline underline-offset-4"
                 >
-                  Sign in
+                  {appLanguageContext.signInLabel}
                 </Link>
               </div>
             </form>

--- a/components/translations-history-skeleton.tsx
+++ b/components/translations-history-skeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from './ui/skeleton';
 
 export async function TranslationsHistorySkeleton() {
   return (
-    <div className="space-y-4 pb-4 md:pb-0 border rounded-md p-4 w-full md:h-[750px] flex flex-col">
+    <div className="space-y-4 p-4 pb-0 border rounded-md w-full md:h-[750px] flex flex-col">
       <h3 className="mb-3 text-xl font-medium">Translation History</h3>
 
       <form>
@@ -17,7 +17,7 @@ export async function TranslationsHistorySkeleton() {
         />
       </form>
 
-      <div className="overflow-y-auto h-full p-4 bg-background">
+      <div className="overflow-y-auto h-full bg-background">
         <TranslationSkeletonCard />
         <TranslationSkeletonCard />
         <TranslationSkeletonCard />

--- a/config/app-language-context.ts
+++ b/config/app-language-context.ts
@@ -5,6 +5,11 @@ const languageContexts = {
     title: 'Tradutor Inteligente',
     signInLabel: 'Entrar',
     signUpLabel: 'Registrar',
+    userOptions: {
+      hello: 'Olá',
+      signOut: 'Sair',
+      profile: 'Perfil',
+    },
     heroSection: {
       title: 'Tradutor Inteligente com IA',
       description:
@@ -27,6 +32,13 @@ const languageContexts = {
       serviceTerms: 'Termos de Serviço',
       privacyPolicy: 'Política de Privacidade',
       contact: 'Contato',
+    },
+    auth: {
+      signInDescription: 'Digite seu e-mail abaixo para entrar na sua conta',
+      doNotHaveAccount: 'Não tem uma conta?',
+      signedInSuccessfully: 'Logado com sucesso!',
+      signUpDescription: 'Digite seu e-mail abaixo para registrar sua conta',
+      alreadyHaveAccount: 'Já tem uma conta?',
     },
     dashboard: {
       form: {
@@ -61,6 +73,11 @@ const languageContexts = {
     title: 'Smart Translator',
     signInLabel: 'Sign In',
     signUpLabel: 'Sign Up',
+    userOptions: {
+      hello: 'Hello',
+      signOut: 'Sign Out',
+      profile: 'Profile',
+    },
     heroSection: {
       title: 'AI-Powered Smart Translator',
       description:
@@ -82,6 +99,13 @@ const languageContexts = {
       serviceTerms: 'Terms of Service',
       privacyPolicy: 'Privacy Policy',
       contact: 'Contact',
+    },
+    auth: {
+      signInDescription: 'Enter your email below to login to your account',
+      doNotHaveAccount: "Don't have an account?",
+      signedInSuccessfully: 'Signed in successfully!',
+      signUpDescription: 'Enter your email below to register to your account',
+      alreadyHaveAccount: 'Already have an account?',
     },
     dashboard: {
       form: {

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -44,8 +44,7 @@ const portugueseFeatures = [
 export type Plan = {
   type: 'free' | 'paid';
   title: string;
-  price: number;
-  currency: 'usd' | 'brl';
+  usdPrice: number;
   status: { available: boolean; reason?: string };
   features: { title: string; available: boolean }[];
 };
@@ -54,8 +53,7 @@ const englishPlans: Plan[] = [
   {
     type: 'free',
     title: 'Free',
-    price: 0,
-    currency: 'usd',
+    usdPrice: 0,
     status: { available: true },
     features: [
       {
@@ -83,8 +81,7 @@ const englishPlans: Plan[] = [
   {
     type: 'paid',
     title: 'Premium',
-    price: 9.99,
-    currency: 'usd',
+    usdPrice: 9.99,
     status: { available: false, reason: 'Coming Soon' },
     features: [
       {
@@ -115,8 +112,7 @@ const portuguesePlans: Plan[] = [
   {
     type: 'free',
     title: 'Free',
-    price: 0,
-    currency: 'brl',
+    usdPrice: 0,
     status: { available: true },
     features: [
       {
@@ -144,8 +140,7 @@ const portuguesePlans: Plan[] = [
   {
     type: 'paid',
     title: 'Premium',
-    price: 57.0,
-    currency: 'brl',
+    usdPrice: 9.99,
     status: { available: false, reason: 'Em Breve' },
     features: [
       {


### PR DESCRIPTION
## Done
- Adjusted `PlanCard` component to have only usd prices
- Implemented `language context` approach in auth layout `back button`
- Implemented `auth` translated texts to `languageContexts` object
- Implemented `language context` approach in `/sign-in` page
- Implemented `language context` approach in `/sign-up` page
- Implemented `language context` approach to `userOptions` in header
- Adjusted styles of `translations-history-skeleton` component
- Added `animate-pulse` to the `ChangeLanguageButton` component

## Preview
[Gravação de tela de 26-03-2025 20:45:16.webm](https://github.com/user-attachments/assets/1b30ed0e-1297-4c4d-a147-85f583f0c317)

