### PR TITLE
Feat/translations soft delete

### DIFF
--- a/app/(private)/dashboard/_components/translations-history/delete-confirmation-modal.tsx
+++ b/app/(private)/dashboard/_components/translations-history/delete-confirmation-modal.tsx
@@ -4,13 +4,15 @@ import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
 import type { AvailableLanguages } from '@/config/constants';
-import { TrashIcon } from 'lucide-react';
+import { ArrowRight, TrashIcon } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { discardTranslationAction } from '../../actions';
 import type { TranslationsWithPhrases } from './content';
 
 const englishDescription =
@@ -28,17 +30,32 @@ export function DeleteConfirmationModal({
   language,
   translationToDelete,
 }: DeleteConfirmationModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
   const buttonTitle = language === 'en' ? 'Delete' : 'Deletar';
   const dialogTitle =
     language === 'en' ? 'Delete translation' : 'Deletar tradução';
+  const cancelButtonTitle = language === 'en' ? 'Cancel' : 'Cancelar';
 
   const dialogDescription =
     language === 'en' ? englishDescription : portugueseDescription;
 
   const translationLabel = language === 'en' ? 'Translation' : 'Tradução';
+  const languageLabel = language === 'en' ? 'Language' : 'Idioma';
+
+  async function handleDiscard() {
+    const message =
+      language === 'en'
+        ? 'Translation deleted successfully'
+        : 'Tradução deletada com sucesso';
+
+    await discardTranslationAction(translationToDelete.id);
+    toast.success(message);
+    setIsOpen(false);
+  }
 
   return (
-    <Dialog>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button
           variant="destructive"
@@ -54,20 +71,52 @@ export function DeleteConfirmationModal({
           <DialogTitle>{dialogTitle}</DialogTitle>
         </DialogHeader>
 
-        <DialogDescription>
-          <div>
-            <p className="mb-4">{dialogDescription}</p>
-            <div className="text-sm font-semibold flex flex-col">
-              <span className="text-sm text-muted-foreground">
-                {translationLabel}
-              </span>
-              <p>
-                {translationToDelete.targetWord} -{' '}
-                {translationToDelete.translatedWord}
-              </p>
+        <div>
+          <p className="mb-4">{dialogDescription}</p>
+          <div className="text-sm font-semibold flex flex-col">
+            <div className="flex gap-4">
+              <div>
+                <span className="text-sm text-muted-foreground">
+                  {languageLabel}
+                </span>
+                <div className="flex gap-2 items-center border-r-2 pr-4">
+                  <span>{translationToDelete.languageFrom}</span>
+                  <span className="text-muted-foreground">
+                    <ArrowRight className="size-4" />
+                  </span>
+                  <span>{translationToDelete.languageTo}</span>
+                </div>
+              </div>
+
+              <div>
+                <span className="text-sm text-muted-foreground">
+                  {translationLabel}
+                </span>
+                <div className="flex gap-2 items-center">
+                  <span>{translationToDelete.targetWord}</span>
+                  <span className="text-muted-foreground">
+                    <ArrowRight className="size-4" />
+                  </span>
+                  <span>{translationToDelete.translatedWord}</span>
+                </div>
+              </div>
             </div>
           </div>
-        </DialogDescription>
+
+          <fieldset className="flex gap-2 justify-end">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setIsOpen(false);
+              }}
+            >
+              {cancelButtonTitle}
+            </Button>
+            <Button variant="destructive" onClick={() => handleDiscard()}>
+              {buttonTitle}
+            </Button>
+          </fieldset>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/app/(private)/dashboard/_components/translations-history/index.tsx
+++ b/app/(private)/dashboard/_components/translations-history/index.tsx
@@ -12,6 +12,7 @@ export async function TranslationsHistory() {
   const translations = await prismaClient.translations.findMany({
     where: {
       userId: user.id,
+      discarted: false,
     },
     include: {
       phrases: true,

--- a/app/(private)/dashboard/_components/translations-history/index.tsx
+++ b/app/(private)/dashboard/_components/translations-history/index.tsx
@@ -12,7 +12,7 @@ export async function TranslationsHistory() {
   const translations = await prismaClient.translations.findMany({
     where: {
       userId: user.id,
-      discarted: false,
+      discarded: false,
     },
     include: {
       phrases: true,

--- a/app/(private)/dashboard/actions.ts
+++ b/app/(private)/dashboard/actions.ts
@@ -176,3 +176,19 @@ export async function findTranslationsAction(searchTerm: string) {
 
   return translations;
 }
+
+export async function discardTranslationAction(translationId: string) {
+  const user = await checkUserAction();
+
+  await prismaClient.translations.update({
+    where: {
+      id: translationId,
+      userId: user.id,
+    },
+    data: {
+      discarted: true,
+    },
+  });
+
+  revalidatePath('/dashboard');
+}

--- a/app/(private)/dashboard/actions.ts
+++ b/app/(private)/dashboard/actions.ts
@@ -186,7 +186,7 @@ export async function discardTranslationAction(translationId: string) {
       userId: user.id,
     },
     data: {
-      discarted: true,
+      discarded: true,
     },
   });
 

--- a/app/(private)/dashboard/page.tsx
+++ b/app/(private)/dashboard/page.tsx
@@ -23,6 +23,7 @@ export default async function Page() {
   const latestTranslation = await prismaClient.translations.findFirst({
     where: {
       userId: user.id,
+      discarted: false,
     },
     include: {
       phrases: true,
@@ -65,7 +66,7 @@ export default async function Page() {
       <div className="flex flex-col justify-between gap-4 w-full md:h-[750px]">
         <div className="w-full">
           <div className="rounded-t-md flex flex-col border p-6">
-            <div className="flex justify-between items-center">
+            <div className="flex justify-between items-center flex-col sm:flex-row">
               <h2 className="text-xl font-bold">
                 {dashboardLanguage.form.title}
               </h2>

--- a/app/(private)/dashboard/page.tsx
+++ b/app/(private)/dashboard/page.tsx
@@ -23,7 +23,7 @@ export default async function Page() {
   const latestTranslation = await prismaClient.translations.findFirst({
     where: {
       userId: user.id,
-      discarted: false,
+      discarded: false,
     },
     include: {
       phrases: true,

--- a/prisma/migrations/20250331012507_adds_discarted_column_to_translations_table/migration.sql
+++ b/prisma/migrations/20250331012507_adds_discarted_column_to_translations_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "translations" ADD COLUMN     "discarted" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20250331015753_fix_translations_column_typo/migration.sql
+++ b/prisma/migrations/20250331015753_fix_translations_column_typo/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `discarted` on the `translations` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "translations" DROP COLUMN "discarted",
+ADD COLUMN     "discarded" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Translations {
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
   userId         String   @map("user_id") @db.Uuid
-  discarted      Boolean  @default(false)
+  discarded      Boolean  @default(false)
 
   user    Users                @relation(fields: [userId], references: [id])
   phrases TranslationPhrases[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Translations {
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
   userId         String   @map("user_id") @db.Uuid
+  discarted      Boolean  @default(false)
 
   user    Users                @relation(fields: [userId], references: [id])
   phrases TranslationPhrases[]


### PR DESCRIPTION
## Done
- Added column `discarded` in `translations` table
- Created `server action` to update `discarted` prop to true in `translations` table
- Integrated `discardTranslationAction` server action with frontend
- Adjusted `TranslationsHistory` component to search only translations with `discarted` prop equals to false

## Preview
[Gravação de tela de 30-03-2025 22:47:15.webm](https://github.com/user-attachments/assets/1c30c8d6-fabf-4bd9-a160-4b70dae23800)
