### PR TITLE
Creates admin `leads` page (first version)

### DIFF
--- a/actions/auth/check-user.ts
+++ b/actions/auth/check-user.ts
@@ -2,16 +2,11 @@
 
 import { projectConstants } from '@/config/constants';
 import { prismaClient } from '@/lib/prisma-client';
-import type { Roles } from '@prisma/client';
 import { jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-type CheckUserActionProps = {
-  role?: Roles | null;
-};
-
-export async function checkUserAction({ role }: CheckUserActionProps = {}) {
+export async function checkUserAction() {
   const cookieStorage = await cookies();
   const token = cookieStorage.get(projectConstants.accessToken)?.value;
 
@@ -30,10 +25,6 @@ export async function checkUserAction({ role }: CheckUserActionProps = {}) {
     });
 
     if (!user) return redirect('/auth/sign-in?action=logout');
-
-    if (role && user.role !== role) {
-      return redirect('/auth/sign-in?action=unauthorized');
-    }
 
     return user;
   } catch {

--- a/actions/auth/check-user.ts
+++ b/actions/auth/check-user.ts
@@ -2,11 +2,16 @@
 
 import { projectConstants } from '@/config/constants';
 import { prismaClient } from '@/lib/prisma-client';
+import type { Roles } from '@prisma/client';
 import { jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-export async function checkUserAction() {
+type CheckUserActionProps = {
+  role?: Roles | null;
+};
+
+export async function checkUserAction({ role }: CheckUserActionProps = {}) {
   const cookieStorage = await cookies();
   const token = cookieStorage.get(projectConstants.accessToken)?.value;
 
@@ -25,6 +30,10 @@ export async function checkUserAction() {
     });
 
     if (!user) return redirect('/auth/sign-in?action=logout');
+
+    if (role && user.role !== role) {
+      return redirect('/auth/sign-in?action=unauthorized');
+    }
 
     return user;
   } catch {

--- a/app/(private)/dashboard/(admin)/leads/page.tsx
+++ b/app/(private)/dashboard/(admin)/leads/page.tsx
@@ -1,0 +1,25 @@
+import { checkUserAction } from '@/actions/auth/check-user';
+import { prismaClient } from '@/lib/prisma-client';
+
+export default async function Page() {
+  const user = await checkUserAction({ role: 'ADMIN' });
+
+  const leads = await prismaClient.plansWaitList.findMany();
+
+  return (
+    <main className="h-full p-4">
+      {leads.length === 0 && (
+        <div className="flex flex-col gap-2">
+          <h2>No leads found</h2>
+        </div>
+      )}
+
+      {leads.map((lead) => (
+        <div key={lead.email} className="flex flex-col gap-2">
+          <h2>{lead.email}</h2>
+          <p>{lead.createdAt.toString()}</p>
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/app/(private)/dashboard/(admin)/leads/page.tsx
+++ b/app/(private)/dashboard/(admin)/leads/page.tsx
@@ -1,8 +1,12 @@
 import { checkUserAction } from '@/actions/auth/check-user';
 import { prismaClient } from '@/lib/prisma-client';
+import { redirect } from 'next/navigation';
 
 export default async function Page() {
-  const user = await checkUserAction({ role: 'ADMIN' });
+  const user = await checkUserAction();
+  if (user.role !== 'ADMIN') {
+    return redirect('/dashboard');
+  }
 
   const leads = await prismaClient.plansWaitList.findMany();
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -3,7 +3,7 @@ import { getAppLanguageAction } from '@/app/actions';
 import { getLanguageContext } from '@/config/app-language-context';
 import { prismaClient } from '@/lib/prisma-client';
 import type { Users as User } from '@prisma/client';
-import { Globe, LogOutIcon, User2Icon } from 'lucide-react';
+import { ChartLine, Globe, LogOutIcon, User2Icon } from 'lucide-react';
 import Link from 'next/link';
 import { MenuIcon } from './menu-icon';
 import { ToggleTheme } from './toggle-theme';
@@ -93,6 +93,15 @@ export async function Header({ user }: HeaderProps) {
                   {appLanguageContext.userOptions.profile}
                 </Link>
               </Button>
+
+              {user.role === 'ADMIN' && (
+                <Button asChild variant="ghost">
+                  <Link href="/dashboard/leads">
+                    <ChartLine />
+                    {appLanguageContext.userOptions.leads}
+                  </Link>
+                </Button>
+              )}
 
               <form action={logout}>
                 <Button className="w-full" variant="destructive">

--- a/components/plan-card.tsx
+++ b/components/plan-card.tsx
@@ -15,7 +15,7 @@ export function PlanCard({ plan, language }: PlanCardProps) {
   return (
     <Card
       className={cn(
-        'max-w-[420px] h-[582px] w-full p-6 flex flex-col relative space-y-4 hover:shadow-xl transition-shadow',
+        'max-w-[420px] h-[600px] w-full p-6 flex flex-col relative space-y-4 hover:shadow-xl transition-shadow',
       )}
     >
       <CardHeader className="pt-0">

--- a/config/app-language-context.ts
+++ b/config/app-language-context.ts
@@ -9,6 +9,7 @@ const languageContexts = {
       hello: 'Olá',
       signOut: 'Sair',
       profile: 'Perfil',
+      leads: 'Ver Leads',
     },
     heroSection: {
       title: 'Tradutor Inteligente com IA',
@@ -94,6 +95,7 @@ const languageContexts = {
       hello: 'Hello',
       signOut: 'Sign Out',
       profile: 'Profile',
+      leads: 'See Leads',
     },
     heroSection: {
       title: 'AI-Powered Smart Translator',

--- a/prisma/migrations/20250404002945_adds_date_columns_in_plans_wait_list_table/migration.sql
+++ b/prisma/migrations/20250404002945_adds_date_columns_in_plans_wait_list_table/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `updated_at` to the `plans_wait_list` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "plans_wait_list" ADD COLUMN     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,8 +73,10 @@ model Plans {
 }
 
 model PlansWaitList {
-  email  String @unique
-  planId String @map("plan_id") @db.Uuid
+  email     String   @unique
+  planId    String   @map("plan_id") @db.Uuid
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   plan Plans @relation(fields: [planId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## Done
- Added `created_at` and `updated_at` fields on `plans_wait_list` table
- Added `see leads` button to `UserOptions` only to admin users
- Adjusted `checkUserAction` to receive optional `role` an check if user matches with it
- Created initial `/dashboard/leads` page to admin users

## Preview
[Gravação de tela de 03-04-2025 22:06:33.webm](https://github.com/user-attachments/assets/240b5b44-57cf-4461-be90-31492cd5c8f6)
