### PR TITLE
[`Development`]: Prompt adjustments and create `releases` page

### DIFF
--- a/app/(private)/dashboard/_components/translations-history/content.tsx
+++ b/app/(private)/dashboard/_components/translations-history/content.tsx
@@ -85,24 +85,24 @@ export function TranslationsHistoryContent({
                 <div className="flex flex-col gap-3">
                   <div
                     className={cn(
-                      'flex font-bold items-center gap text-md',
+                      'flex font-bold items-center gap-1 text-md',
                       isHardModeAvailable && 'flex-col items-start',
                     )}
                   >
-                    <div className="space-x-1">
+                    <div className="flex gap-1 items-center">
                       <span className="capitalize">
                         {translation.targetWord}
                       </span>
                       <small>({translation.languageFrom})</small>
                     </div>
 
-                    <div className="space-x-1">
+                    <div className="flex gap-1">
                       {isHardModeAvailable ? (
                         <span className="text-sm font-normal text-muted-foreground">
                           {translation.wordOverview}
                         </span>
                       ) : (
-                        <div>
+                        <div className="flex gap-1 items-center">
                           <span className="capitalize">
                             {'='} {translation.translatedWord}
                           </span>

--- a/app/(private)/dashboard/page.tsx
+++ b/app/(private)/dashboard/page.tsx
@@ -87,19 +87,19 @@ export default async function Page() {
                         isHardModeAvailable && 'flex-col items-start',
                       )}
                     >
-                      <div className="font-bold space-x-1">
+                      <div className="font-bold flex gap-1 items-center">
                         <span className="capitalize">
                           {latestTranslation.targetWord}
                         </span>
                         <small>({latestTranslation.languageFrom})</small>
                       </div>
-                      <div className="space-x-1">
+                      <div className="flex gap-1">
                         {isHardModeAvailable ? (
                           <span className="text-muted-foreground text-sm">
                             {latestTranslation.wordOverview}
                           </span>
                         ) : (
-                          <div className="font-bold">
+                          <div className="font-bold flex gap-1 items-center">
                             <span className="capitalize">
                               {'= '} {latestTranslation.translatedWord}
                             </span>

--- a/app/(private)/dashboard/releases/page.tsx
+++ b/app/(private)/dashboard/releases/page.tsx
@@ -1,0 +1,34 @@
+import { prismaClient } from '@/lib/prisma-client';
+
+export default async function Page() {
+  const notifications = await prismaClient.notifications.findMany();
+
+  return (
+    <div className="p-6 flex flex-col gap-4">
+      <h2 className="text-3xl font-bold">Releases</h2>
+
+      <ul className="relative flex-1 pr-4 h-full">
+        <div className="h-fit border-l flex flex-col justify-between gap-10 border-muted">
+          {notifications.map((notification) => (
+            <li
+              key={notification.id}
+              className="ml-4 h-40 bg-secondary rounded-md shadow-sm"
+            >
+              <section id={notification.slug} className="relative h-full">
+                <div className="absolute w-3 h-3 bg-primary rounded-full -left-5.5 top-16" />
+
+                <div className="flex flex-col gap-2 p-4">
+                  <h3 className="text-xl font-semibold">{notification.name}</h3>
+                  <time className="text-sm text-muted-foreground">
+                    {new Date(notification.createdAt).toLocaleDateString()}
+                  </time>
+                  <p>{notification.description}</p>
+                </div>
+              </section>
+            </li>
+          ))}
+        </div>
+      </ul>
+    </div>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -101,6 +101,13 @@ export async function Header({ user }: HeaderProps) {
                 </Link>
               </Button>
 
+              <Button asChild variant="ghost">
+                <Link href="/dashboard/releases">
+                  <User2Icon />
+                  {appLanguageContext.userOptions.release}
+                </Link>
+              </Button>
+
               {user.role === 'ADMIN' && (
                 <Button asChild variant="ghost">
                   <Link href="/dashboard/leads">

--- a/components/notification.tsx
+++ b/components/notification.tsx
@@ -52,7 +52,10 @@ export async function Notification() {
             availableNotifications.map((notification) => (
               <div key={notification.id}>
                 <div className="relative isolate w-full hover:bg-muted transition-all p-2 rounded-md cursor-pointer flex flex-col">
-                  <Link href="#" className="font-bold">
+                  <Link
+                    href={`/dashboard/releases#${notification.slug}`}
+                    className="font-bold"
+                  >
                     {notification.name}
                     <span className="absolute inset-0 z-30" />
                   </Link>

--- a/config/app-language-context.ts
+++ b/config/app-language-context.ts
@@ -9,6 +9,7 @@ const languageContexts = {
       hello: 'Olá',
       signOut: 'Sair',
       profile: 'Perfil',
+      release: 'Notas de Lançamento',
       leads: 'Ver Leads',
     },
     heroSection: {
@@ -106,6 +107,7 @@ Em vez de traduções diretas, você receberá uma breve explicação e frases d
       hello: 'Hello',
       signOut: 'Sign Out',
       profile: 'Profile',
+      release: 'Release Notes',
       leads: 'See Leads',
     },
     heroSection: {

--- a/models/gemini.ts
+++ b/models/gemini.ts
@@ -156,7 +156,10 @@ Generate an output **ONLY in valid JSON format**, without any other characters, 
   input_brief_overview_in_language_from: string
 }
 
-Please generate "input_brief_overview_in_language_from" in this language ${formattedLanguageFrom}.
+Provide a very short and direct description of the word to “input_brief_overview_in_language_from” in ${formattedLanguageFrom}:
+  - Do not translate the word.
+  - Use no more than 10 words for the description.
+  - Make it concise, without unnecessary context.
 
 But, in case of the word is not a valid ${formattedLanguageFrom} word, ignore the command to **ONLY in valid JSON format** and return an empty object.
   `;


### PR DESCRIPTION
# DONE:
- Improved gemini prompt to generate shorter words description
- Adjusted spacing of translations card
- Created /dashboard/releases page